### PR TITLE
[WIP] Deploy staging site via github actions

### DIFF
--- a/.github/workflows/deploy_staging_self_hosted.yml
+++ b/.github/workflows/deploy_staging_self_hosted.yml
@@ -1,0 +1,20 @@
+name: deploy staging on self-hosted
+
+on:
+  push:
+    branches: [ dev ]
+  workflow_dispatch:
+
+jobs:
+  deploy_staging:
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Deploy staging app
+        run: |
+          cd ~/GATE/gate-annotation-service/
+          git checkout dev
+          git pull
+          ./deploy.sh staging


### PR DESCRIPTION
Here I'm testing out one possible approach to deploying a site via github actions. I'd be interested in discussing this before I go any further. I've tested this on my local machine and whilst it does actually work, it may not be the best way to go.

This takes a very basic (and maybe dangerous) approach of just `cd`ing to a directory on the server (which has to be set up as a self-hosted runner), checking out the `dev` branch, pulling and running the `./deploy.sh staging` command which builds the docker images. I'd be interested to hear whether people think this is a dumb idea and what might be a better approach.

If we wanted to follow this idea then In order to set things up on the server we would need to:
- [ ] create separate directories on the server for the source code for the staging and production apps,
- [ ] install docker and docker-compose on the server if not already,
- [ ] set up the self-hosted runner and give it tags specific to this project since runners are set up at the organisation level (if I'm not mistaken)
      - note that we'd only need one runner to handle both sites.
- [ ] keep the runner on the server up as a service (I guess?)

A better approach may be to build the containers on github and push them to a container registry (I've used dockerhub and github container registry before) and pull them to the server somehow, maybe via another action via a self-hosted runner, or via a cronjob or something to check for new images.