### PR TITLE
Copy package.json in /frontend too as the root package.json requires it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:12-buster-slim as nodebuilder
 COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json ./frontend/
 RUN npm install --unsafe-perm --only=production
 COPY frontend/ ./frontend/
 RUN npm run build


### PR DESCRIPTION
The root `package.json` has a postinstall script that runs npm install inside the frontend folder. So we also need to copy frontend folder's `package.json` and `package-lock.json` too.