### PR TITLE
only run coverage report on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Run backend test with codecov report
         run: npm run test:backend-cov
       - name: Pytest coverage comment
+        if: ${{ github.event_name == 'pull_request'}}
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt


### PR DESCRIPTION
Small addition to the previous PR's workflow so that code coverage reports are only run on pull requests, not on pushes to the main or dev branches.