### PR TITLE
use backup user with correct permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   pgbackups:
     image: prodrigestivill/postgres-backup-local
     restart: always
-    user: postgres:postgres
+    user: 1002:1155
     volumes:
       - ${BACKUPS_VOLUME}:/backups
     depends_on:


### PR DESCRIPTION
I've tested this on derwent and seems to result in the right permissions, hopefully meaning that the backup container can create the backups, which it hasn't been able to do so far..