### PR TITLE
Actions workflow to push images to ghcr.io

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,69 @@
+name: build-docker
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'dev'
+    tags:
+      - "v*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta (backend)
+        id: metaBackend
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/gatenlp/teamware-backend
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      -
+        name: Docker meta (static files)
+        id: metaStatic
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/gatenlp/teamware-static
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push backend
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          target: backend
+          push: true
+          tags: ${{ steps.metaBackend.outputs.tags }}
+          labels: ${{ steps.metaBackend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      -
+        name: Build and push static files
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          target: frontend
+          push: true
+          tags: ${{ steps.metaStatic.outputs.tags }}
+          labels: ${{ steps.metaStatic.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Builds docker images and pushes them to `ghcr.io/gatenlp/teamware-{backend,static}` on any push to:

- `master` branch -> images tagged as `master`
- `dev` branch -> `dev`
- any semver-style tag `vX.Y.Z` -> `vX.Y.Z`, `vX.Y` and `latest`