### PR TITLE
move setting of ALLOWED_HOSTS to .env

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,16 +7,18 @@ DEPLOY_ENV=$1
 DJANGO_SETTINGS_MODULE=teamware.settings.deployment
 export DJANGO_SETTINGS_MODULE
 
+source .env
+
 case $DEPLOY_ENV in
 
   production|prod)
-    DJANGO_ALLOWED_HOSTS=annotate.gate.ac.uk
+    DJANGO_ALLOWED_HOSTS=$TEAMWARE_HOST_URL_PRODUCTION
     export DJANGO_ALLOWED_HOSTS
     echo "Deploying with DJANGO_ALLOWED_HOSTS: $DJANGO_ALLOWED_HOSTS"
     ;;
 
   staging|stag)
-    DJANGO_ALLOWED_HOSTS=annotate-test.gate.ac.uk
+    DJANGO_ALLOWED_HOSTS=$TEAMWARE_HOST_URL_STAGING
     export DJANGO_ALLOWED_HOSTS
     echo "Deploying with DJANGO_ALLOWED_HOSTS: $DJANGO_ALLOWED_HOSTS"
     ;;

--- a/generate-docker-env.sh
+++ b/generate-docker-env.sh
@@ -20,19 +20,16 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 case $BRANCH in 
     master|main)
         # production build
-        DEPLOY_ENV=production
         MAIN_IMAGE=${MAIN_IMAGE:-teamware-backend}
         STATIC_IMAGE=${STATIC_IMAGE:-teamware-static}
         ;;
     dev)
         # staging build
-        DEPLOY_ENV=staging
         MAIN_IMAGE=${MAIN_IMAGE:-teamware-backend-staging}
         STATIC_IMAGE=${STATIC_IMAGE:-teamware-static-staging}
         ;;
     *)
         # other builds, e.g. in development
-        DEPLOY_ENV=development
         MAIN_IMAGE=${MAIN_IMAGE:-teamware-backend-dev}
         STATIC_IMAGE=${STATIC_IMAGE:-teamware-static-dev}
         ;;
@@ -56,6 +53,9 @@ DB_PASSWORD=${DB_PASSWORD:-$(openssl rand -base64 16)} # default: auto-generated
 DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-teamware.settings.deployment}
 DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-$(openssl rand -base64 42)} # default: auto-generated
 
+# Allowed host urls
+TEAMWARE_HOST_URL_PRODUCTION=${TEAMWARE_HOST_URL_PRODUCTION}
+TEAMWARE_HOST_URL_STAGING=${TEAMWARE_HOST_URL_STAGING}
 
 # Database backup user credentials
 DB_BACKUP_USER=${DB_BACKUP_USER:-backup}
@@ -66,9 +66,6 @@ BACKUPS_VOLUME=${BACKUPS_VOLUME:-/var/lib/teamware-backup/}
 
 # User permissions for the backup user on the host filesystem (user:group)
 BACKUPS_USER_GROUP=${BACKUPS_USER_GROUP:-0:0}
-
-# Set automatically as production, staging or development based on branch (master, dev, other)
-DEPLOY_ENV=$DEPLOY_ENV
 
 # Default credentials user for setting up database
 # Only used if no superusers are found in database


### PR DESCRIPTION
This moves the setting of `DJANGO_ALLOWED_HOSTS` out of being hard-coded in `deploy.sh` and into the `.env`