### PR TITLE
Allows annotator to back and edit previous annotations in the Annotation screen

### DIFF
--- a/.github/workflows/image-build-integration-tests.yml
+++ b/.github/workflows/image-build-integration-tests.yml
@@ -53,6 +53,7 @@ jobs:
           start: /bin/bash deploy.sh production
           wait-on: 'http://localhost:8076'
           config: baseUrl=http://localhost:8076
+          record: true
         env:
           CYPRESS_TESTENV: ci
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/backend/management/commands/load_test_fixture.py
+++ b/backend/management/commands/load_test_fixture.py
@@ -34,10 +34,9 @@ def create_db_users():
     annotator.is_account_activated = True
     annotator.save()
 
-
 @test_fixture
-def create_db_users_with_project_and_annotation():
-    """Create default db users and also create a set of annotation."""
+def create_db_users_with_project():
+    """Create default db users and also create a project that belongs to an admin."""
     create_db_users()
     admin_user = get_user_model().objects.get(username="admin")
     manager_user = get_user_model().objects.get(username="manager")
@@ -76,6 +75,26 @@ def create_db_users_with_project_and_annotation():
             "text": f"Document text {i}"
         }
         document = Document.objects.create(project=project, data=doc_data)
+
+@test_fixture
+def create_db_users_with_project_admin_is_annotator():
+    create_db_users_with_project()
+    admin_user = get_user_model().objects.get(username="admin")
+    project = Project.objects.get(name="Test project")
+    project.add_annotator(admin_user)
+
+
+@test_fixture
+def create_db_users_with_project_and_annotation():
+    """Create default db users and also create a set of annotation."""
+    create_db_users_with_project()
+    admin_user = get_user_model().objects.get(username="admin")
+    manager_user = get_user_model().objects.get(username="manager")
+    annotator_user = get_user_model().objects.get(username="annotator")
+    users = [admin_user, manager_user, annotator_user]
+
+    documents = Document.objects.all()
+    for document in documents:
         for user in users:
             annotation = Annotation.objects.create(document=document, user=user,
                                                status=Annotation.COMPLETED, status_time=timezone.now())

--- a/backend/models.py
+++ b/backend/models.py
@@ -287,9 +287,6 @@ class Project(models.Model):
         except ObjectDoesNotExist:
             raise Exception("User must be added to the project before they can be made active.")
 
-
-
-
     def annotator_completed_training(self, user, finished_time=timezone.now()):
         try:
             annotator_project = AnnotatorProject.objects.get(project=self, annotator=user)
@@ -498,7 +495,6 @@ class Project(models.Model):
             else:
                 return self.decide_annotator_task_type_and_assign(user)
 
-
     def annotator_reached_quota(self, user):
 
         num_user_annotated_docs = (self.get_annotator_completed_documents_query(user) |
@@ -541,18 +537,22 @@ class Project(models.Model):
             "document_data": document.data,
             "document_type": document.doc_type_str,
             "annotation_id": annotation.pk,
+            "annotation_data": annotation.data,
             "allow_document_reject": self.allow_document_reject,
             "annotation_timeout": annotation.times_out_at,
             "annotator_remaining_tasks": self.num_annotator_task_remaining(user=annotation.user),
             "annotator_completed_tasks": self.get_annotator_completed_documents_query(user=annotation.user).count(),
-            "annotator_completed_training_tasks": self.get_annotator_completed_documents_query(user=annotation.user, doc_type=DocumentType.TRAINING).count(),
-            "annotator_completed_test_tasks": self.get_annotator_completed_documents_query(user=annotation.user, doc_type=DocumentType.TEST).count(),
+            "annotator_completed_training_tasks": self.get_annotator_completed_documents_query(user=annotation.user,
+                                                                                               doc_type=DocumentType.TRAINING).count(),
+            "annotator_completed_test_tasks": self.get_annotator_completed_documents_query(user=annotation.user,
+                                                                                           doc_type=DocumentType.TEST).count(),
             "document_gold_standard_field": self.document_gold_standard_field,
         }
 
         if include_task_history_in_project and document.doc_type is DocumentType.ANNOTATION:
             # If specified, also returns a list of annotation ids for this user in the project
-            output["task_history"] = Annotation.get_annotations_for_user_in_project(annotation.user.pk, self.pk)
+            output["task_history"] = [annotation.pk for annotation in
+                                      Annotation.get_annotations_for_user_in_project(annotation.user.pk, self.pk)]
 
         return output
 
@@ -565,7 +565,6 @@ class Project(models.Model):
             "project_config": self.configuration,
             "project_id": self.pk,
         }
-
 
     def decide_annotator_task_type_and_assign(self, user):
         """
@@ -863,7 +862,6 @@ class Document(models.Model):
         return doc_dict
 
 
-
 class Annotation(models.Model):
     """
     Model to represent a single annotation.
@@ -971,10 +969,6 @@ class Annotation(models.Model):
                                                annotation=self,
                                                changed_by=by_user)
 
-
-
-
-
     def latest_annotation_history(self):
         """
         Convenience function for getting the latest annotation data from the change history.
@@ -1031,10 +1025,17 @@ class Annotation(models.Model):
     @staticmethod
     def get_annotations_for_user_in_project(user_id, project_id, doc_type=DocumentType.ANNOTATION):
         """
-        Gets a list of all annotation tasks in the project project_id that belong to the annotator with user_id
+        Gets a list of all completed and pending annotation tasks in the project project_id that belong to the
+        annotator with user_id.
+
+        Ordered by descending date and PK so the most recent entry is placed first.
         """
 
-        return Annotation.objects.filter(document__project_id=project_id, document__doc_type=doc_type, user_id=user_id).order_by("created", "pk").distinct()
+        return Annotation.objects.filter(document__project_id=project_id,
+                                         document__doc_type=doc_type,
+                                         user_id=user_id).distinct().filter(
+            Q(status=Annotation.COMPLETED) | Q(status=Annotation.PENDING)).order_by("-created", "-pk")
+
 
 class AnnotationChangeHistory(models.Model):
     """
@@ -1043,7 +1044,8 @@ class AnnotationChangeHistory(models.Model):
     data = models.JSONField(default=dict)
     time = models.DateTimeField(default=timezone.now)
     annotation = models.ForeignKey(Annotation, on_delete=models.CASCADE, related_name="change_history", null=False)
-    changed_by = models.ForeignKey(get_user_model(), on_delete=models.SET_NULL, related_name="changed_annotations", null=True)
+    changed_by = models.ForeignKey(get_user_model(), on_delete=models.SET_NULL, related_name="changed_annotations",
+                                   null=True)
 
     def get_listing(self):
         return {
@@ -1052,4 +1054,3 @@ class AnnotationChangeHistory(models.Model):
             "time": self.time,
             "changed_by": self.changed_by.username,
         }
-

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -928,6 +928,38 @@ class TestAnnotationModel(ModelTestCase):
                          "Should be changed by annotator2")
 
 
+    def test_get_annotations_for_user_in_project(self):
+        num_projects = 10
+        num_annotators = 12
+        num_annotations_for_annotator = 15
+
+        projects = [Project.objects.create() for i in range(num_projects)]
+        annotators = [get_user_model().objects.create(username=f"Testannotator{i}") for i in range(num_annotators)]
+        doc_types = [DocumentType.ANNOTATION, DocumentType.TRAINING, DocumentType.TEST]
+
+        # Create annotations for all annotators
+        for project in projects:
+            for annotator in annotators:
+                for i in range(num_annotations_for_annotator):
+                    for doc_type in doc_types:
+                        doc = Document.objects.create(project=project, doc_type=doc_type)
+                        Annotation.objects.create(user=annotator, document=doc, status=Annotation.COMPLETED)
+
+
+        # Check for all annotators and projects
+        for project in projects:
+            for annotator in annotators:
+                self.assertEqual(num_annotations_for_annotator,
+                                 len(Annotation.get_annotations_for_user_in_project(annotator.pk, project.pk)))
+                self.assertEqual(num_annotations_for_annotator,
+                                 len(Annotation.get_annotations_for_user_in_project(annotator.pk,
+                                                                                    project.pk,
+                                                                                    DocumentType.TEST)))
+                self.assertEqual(num_annotations_for_annotator,
+                             len(Annotation.get_annotations_for_user_in_project(annotator.pk,
+                                                                                project.pk,
+                                                                                DocumentType.TRAINING)))
+
 
 
 

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -936,26 +936,30 @@ class TestAnnotationModel(ModelTestCase):
         projects = [Project.objects.create() for i in range(num_projects)]
         annotators = [get_user_model().objects.create(username=f"Testannotator{i}") for i in range(num_annotators)]
         doc_types = [DocumentType.ANNOTATION, DocumentType.TRAINING, DocumentType.TEST]
+        anno_status = [Annotation.PENDING, Annotation.COMPLETED,
+                       Annotation.REJECTED, Annotation.ABORTED, Annotation.TIMED_OUT]
 
         # Create annotations for all annotators
         for project in projects:
             for annotator in annotators:
                 for i in range(num_annotations_for_annotator):
                     for doc_type in doc_types:
-                        doc = Document.objects.create(project=project, doc_type=doc_type)
-                        Annotation.objects.create(user=annotator, document=doc, status=Annotation.COMPLETED)
+                        for status in anno_status:
+                            doc = Document.objects.create(project=project, doc_type=doc_type)
+                            Annotation.objects.create(user=annotator, document=doc, status=status)
 
 
         # Check for all annotators and projects
         for project in projects:
             for annotator in annotators:
-                self.assertEqual(num_annotations_for_annotator,
+                # Shows 15 pending and 15 completed annotations
+                self.assertEqual(num_annotations_for_annotator*2,
                                  len(Annotation.get_annotations_for_user_in_project(annotator.pk, project.pk)))
-                self.assertEqual(num_annotations_for_annotator,
+                self.assertEqual(num_annotations_for_annotator*2,
                                  len(Annotation.get_annotations_for_user_in_project(annotator.pk,
                                                                                     project.pk,
                                                                                     DocumentType.TEST)))
-                self.assertEqual(num_annotations_for_annotator,
+                self.assertEqual(num_annotations_for_annotator*2,
                              len(Annotation.get_annotations_for_user_in_project(annotator.pk,
                                                                                 project.pk,
                                                                                 DocumentType.TRAINING)))

--- a/cypress/integration/change-annotation.spec.js
+++ b/cypress/integration/change-annotation.spec.js
@@ -188,6 +188,7 @@ describe('Annotation Change Test in Annotate view', () => {
         // Complete first task
         cy.contains("Neutral").click()
         cy.contains("Submit").click()
+        cy.wait(100)
         cy.contains("Previous task").should("be.enabled")
         cy.contains("Next task").should("be.disabled")
         cy.contains("Current task").should("be.disabled")
@@ -195,12 +196,14 @@ describe('Annotation Change Test in Annotate view', () => {
         // Complete second task
         cy.contains("Neutral").click()
         cy.contains("Submit").click()
+        cy.wait(100)
         cy.contains("Previous task").should("be.enabled")
         cy.contains("Next task").should("be.disabled")
         cy.contains("Current task").should("be.disabled")
 
         // Go back to second task
         cy.contains("Previous task").click()
+        cy.wait(100)
         cy.contains("Previous task").should("be.enabled")
         cy.contains("Next task").should("be.enabled")
         cy.contains("Current task").should("be.enabled")
@@ -210,6 +213,7 @@ describe('Annotation Change Test in Annotate view', () => {
 
         // Go back to first task
         cy.contains("Previous task").click()
+        cy.wait(100)
         cy.contains("Previous task").should("be.disabled")
         cy.contains("Next task").should("be.enabled")
         cy.contains("Current task").should("be.enabled")

--- a/cypress/integration/change-annotation.spec.js
+++ b/cypress/integration/change-annotation.spec.js
@@ -1,4 +1,4 @@
-describe('Annotation Change Test', () => {
+describe('Annotation Change Test in Project documents view and User My annotations view', () => {
 
     let annotatorUsername = "annotator"
     let annotatorEmail = "annotator@test.com"
@@ -11,14 +11,15 @@ describe('Annotation Change Test', () => {
     let password = "testpassword"
 
     beforeEach(()=>{
+        const fixtureName = "create_db_users_with_project_and_annotation"
         // Run setup if needed
         if (Cypress.env('TESTENV') == 'container') {
-            cy.exec('docker-compose exec -T backend ./migrate-integration.sh -n=create_db_users_with_project_and_annotation')
+            cy.exec(`docker-compose exec -T backend ./migrate-integration.sh -n=${fixtureName}`)
         } else if (Cypress.env('TESTENV') == 'ci') {
-            cy.exec('DJANGO_SETTINGS_MODULE=teamware.settings.deployment docker-compose exec -T backend ./migrate-integration.sh -n=create_db_users_with_project_and_annotation')
+            cy.exec(`DJANGO_SETTINGS_MODULE=teamware.settings.deployment docker-compose exec -T backend ./migrate-integration.sh -n=${fixtureName}`)
         }
         else{
-            cy.exec('npm run migrate:integration -- -n=create_db_users_with_project_and_annotation', {log:true})
+            cy.exec(`npm run migrate:integration -- -n=${fixtureName}`, {log:true})
         }
     })
 
@@ -139,6 +140,94 @@ describe('Annotation Change Test', () => {
             cy.wrap(container).contains('"sentiment": "negative"')
             cy.wrap(container).contains('"sentiment": "neutral"')
         })
+
+    })
+
+})
+
+describe('Annotation Change Test in Annotate view', () => {
+
+    let adminUsername = "admin"
+    let adminEmail = "admin@test.com"
+    let password = "testpassword"
+
+    beforeEach(()=>{
+        const fixtureName = "create_db_users_with_project_admin_is_annotator"
+        // Run setup if needed
+        if (Cypress.env('TESTENV') == 'container') {
+            cy.exec(`docker-compose exec -T backend ./migrate-integration.sh -n=${fixtureName}`)
+        } else if (Cypress.env('TESTENV') == 'ci') {
+            cy.exec(`DJANGO_SETTINGS_MODULE=teamware.settings.deployment docker-compose exec -T backend ./migrate-integration.sh -n=${fixtureName}`)
+        }
+        else{
+            cy.exec(`npm run migrate:integration -- -n=${fixtureName}`, {log:true})
+        }
+    })
+
+    it("Change annotation in Annotate view", () => {
+        cy.login(adminUsername, password)
+        cy.visit("/")
+        cy.get(".navbar").contains("Annotate").click()
+        cy.contains("Start annotating").click()
+        // All task navigation buttons should start disabled
+        cy.contains("Previous task").should("be.disabled")
+        cy.contains("Next task").should("be.disabled")
+        cy.contains("Current task").should("be.disabled")
+
+        // Complete first task
+        cy.contains("Neutral").click()
+        cy.contains("Submit").click()
+        cy.contains("Previous task").should("be.enabled")
+        cy.contains("Next task").should("be.disabled")
+        cy.contains("Current task").should("be.disabled")
+
+        // Complete second task
+        cy.contains("Neutral").click()
+        cy.contains("Submit").click()
+        cy.contains("Previous task").should("be.enabled")
+        cy.contains("Next task").should("be.disabled")
+        cy.contains("Current task").should("be.disabled")
+
+        // Go back to second task
+        cy.contains("Previous task").click()
+        cy.contains("Previous task").should("be.enabled")
+        cy.contains("Next task").should("be.enabled")
+        cy.contains("Current task").should("be.enabled")
+        cy.contains("Negative").click()
+        cy.contains("Submit").click()
+        cy.contains("Annotation changed")
+
+        // Go back to first task
+        cy.contains("Previous task").click()
+        cy.contains("Previous task").should("be.disabled")
+        cy.contains("Next task").should("be.enabled")
+        cy.contains("Current task").should("be.enabled")
+        cy.contains("Positive").click()
+        cy.contains("Submit").click()
+        cy.contains("Annotation changed")
+
+        // Forward to second task
+        cy.contains("Next task").click()
+        cy.wait(100)
+        cy.get("input[type='radio'][value='negative']").should('be.checked')
+
+        // Back again to first task
+        cy.contains("Previous task").click()
+        cy.wait(100)
+        cy.get("input[type='radio'][value='positive']").should('be.checked')
+
+        // Back to the latest task, should be blank
+        cy.contains("Current task").click()
+        cy.wait(100)
+        cy.get("input[type='radio'][value='negative']").should('not.be.checked')
+        cy.get("input[type='radio'][value='positive']").should('not.be.checked')
+        cy.get("input[type='radio'][value='neutral']").should('not.be.checked')
+
+
+
+
+
+
 
     })
 

--- a/frontend/src/components/AnnotationRenderer.vue
+++ b/frontend/src/components/AnnotationRenderer.vue
@@ -104,8 +104,15 @@ export default {
     allow_cancel: {
       default: null
     },
+    clear_after_submit: {
+      default: true,
+      type: Boolean
+    }
   },
   methods: {
+    setAnnotationData(data){
+      this.annotationOutput = data
+    },
     startTimer(){
       this.startTime = new Date();
     },
@@ -200,7 +207,8 @@ export default {
 
       if (validationPassed) {
         this.$emit('submit', this.annotationOutput, elapsedTime)
-        this.clearForm()
+        if(this.clear_after_submit)
+          this.clearForm()
         this.startTimer();
       }
     },

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -484,6 +484,16 @@ export default new Vuex.Store({
                 throw e
             }
 
+
+        },
+         async getUserAnnotationTaskWithID({dispatch, commit}, annotationID) {
+            try{
+                let annotationTask = await rpc.call("get_annotation_task_with_id", annotationID)
+                return annotationTask
+            }catch(e){
+                console.error(e)
+                throw e
+            }
         },
         async completeUserAnnotationTask({dispatch, commit}, {annotationID, data, annotationTime}) {
 

--- a/frontend/src/views/Annotate.vue
+++ b/frontend/src/views/Annotate.vue
@@ -153,6 +153,7 @@ export default {
   components: {DeleteModal, CollapseText, MarkdownRenderer, AnnotationRenderer},
   data() {
     return {
+      currentTaskIndex: 0,
       annotationTask: null,
       DocumentType,
       showLeaveProjectModal: false,
@@ -160,7 +161,16 @@ export default {
       showThankyouCard: false,
     }
   },
-  computed: {},
+  computed: {
+    currentAnnotationTask(){
+      if( "task_history" in this.annotationTask){
+
+      }
+      else{
+        return this.annotationTask
+      }
+    }
+  },
   methods: {
     ...mapActions(["getUserAnnotationTask", "completeUserAnnotationTask", "rejectUserAnnotationTask", "annotatorLeaveProject"]),
     getAnnotationContainerBgClass() {

--- a/frontend/src/views/Annotate.vue
+++ b/frontend/src/views/Annotate.vue
@@ -1,9 +1,9 @@
 <template>
   <b-container>
-    <div v-if="annotationTask">
+    <div v-if="currentAnnotationTask">
       <b-row class="mt-4">
         <b-col cols="9">
-          <h1>Annotate: {{ annotationTask.project_name }}</h1>
+          <h1>Annotate: {{ currentAnnotationTask.project_name }}</h1>
 
         </b-col>
         <b-col cols="3" class="text-right">
@@ -13,7 +13,7 @@
         </b-col>
       </b-row>
 
-      <DeleteModal :title="'Leaving project ' + annotationTask.project_name"
+      <DeleteModal :title="'Leaving project ' + currentAnnotationTask.project_name"
                    v-model="showLeaveProjectModal"
                    operation-string="Leave project"
                    @delete="leaveProjectHandler">
@@ -23,61 +23,62 @@
 
 
       <b-card class="mb-4">
-        <div v-if="annotationTask.project_description && annotationTask.project_description.length > 0">
+        <div v-if="currentAnnotationTask.project_description && currentAnnotationTask.project_description.length > 0">
           <h3>Project description</h3>
-          <MarkdownRenderer :content="annotationTask.project_description"></MarkdownRenderer>
+          <MarkdownRenderer :content="currentAnnotationTask.project_description"></MarkdownRenderer>
         </div>
 
-        <div v-if="annotationTask.project_annotator_guideline && annotationTask.project_annotator_guideline.length > 0">
+        <div
+            v-if="currentAnnotationTask.project_annotator_guideline && currentAnnotationTask.project_annotator_guideline.length > 0">
           <h3>Annotator guideline</h3>
           <CollapseText>
-            <MarkdownRenderer :content="annotationTask.project_annotator_guideline"></MarkdownRenderer>
+            <MarkdownRenderer :content="currentAnnotationTask.project_annotator_guideline"></MarkdownRenderer>
           </CollapseText>
         </div>
 
 
       </b-card>
 
-      <div v-if="annotationTask.annotation_id" :class="getAnnotationContainerBgClass()">
+      <div v-if="currentAnnotationTask.annotation_id" :class="getAnnotationContainerBgClass()">
         <b-row>
           <b-col cols="9">
             <h2 :class="getAnnotationSectionHeaderClass()">
               Annotate a document
             </h2>
 
-            <b-badge v-if="annotationTask.document_type !== 'Annotation'"
+            <b-badge v-if="currentAnnotationTask.document_type !== 'Annotation'"
                      class="ml-2 " variant="dark" pill style="font-size: 1.2em">
-              {{ annotationTask.document_type }} stage
+              {{ currentAnnotationTask.document_type }} stage
             </b-badge>
 
           </b-col>
           <b-col class="text-right">
-            <b-badge :title="'Currently annotating document ID: '+annotationTask.document_field_id" class="mr-2">
-              #{{ annotationTask.document_field_id }}
+            <b-badge :title="'Currently annotating document ID: '+currentAnnotationTask.document_field_id" class="mr-2">
+              #{{ currentAnnotationTask.document_field_id }}
             </b-badge>
             <b-badge variant="success"
-                     :title="`You have completed ${annotationTask.annotator_completed_tasks} annotation task(s) in this project.`"
+                     :title="`You have completed ${currentAnnotationTask.annotator_completed_tasks} annotation task(s) in this project.`"
                      class="mr-2">
               <b-icon-check-square-fill></b-icon-check-square-fill>
-              {{ annotationTask.annotator_completed_tasks }}
+              {{ currentAnnotationTask.annotator_completed_tasks }}
             </b-badge>
             <b-badge variant="warning"
-                     :title="`You have ${annotationTask.annotator_remaining_tasks} remaining annotation task(s) in this project.`">
+                     :title="`You have ${currentAnnotationTask.annotator_remaining_tasks} remaining annotation task(s) in this project.`">
               <b-icon-pencil-fill></b-icon-pencil-fill>
-              {{ annotationTask.annotator_remaining_tasks }}
+              {{ currentAnnotationTask.annotator_remaining_tasks }}
             </b-badge>
           </b-col>
         </b-row>
 
         <b-card class="text-center" v-if="showStageIntroCard">
-          <div v-if="annotationTask.document_type === 'Training'">
+          <div v-if="currentAnnotationTask.document_type === 'Training'">
             <h3>Starting training stage</h3>
             <p>
               To familiarise you with the annotation process of this project, you will be annotating some
               example documents. Expected annotation results for each label will be provided.
             </p>
           </div>
-          <div v-else-if="annotationTask.document_type === 'Test'">
+          <div v-else-if="currentAnnotationTask.document_type === 'Test'">
             <h3>Starting test stage</h3>
             <p>
               In this stage, you will be tested to ensure that you can annotate documents in accordance with
@@ -94,15 +95,40 @@
           <b-button variant="primary" @click="showStageIntroCard = false">Start annotating</b-button>
         </b-card>
         <b-card v-else>
-          <AnnotationRenderer :config="annotationTask.project_config"
-                              :document="annotationTask.document_data"
-                              :document_type="annotationTask.document_type"
-                              :doc_gold_field="annotationTask.document_gold_standard_field"
-                              :allow_document_reject="annotationTask.allow_document_reject"
+          <AnnotationRenderer ref="annotationRenderer"
+                              :config="currentAnnotationTask.project_config"
+                              :document="currentAnnotationTask.document_data"
+                              :document_type="currentAnnotationTask.document_type"
+                              :doc_gold_field="currentAnnotationTask.document_gold_standard_field"
+                              :allow_document_reject="isLatestTask() && currentAnnotationTask.allow_document_reject"
+                              :clear_after_submit="clearFormAfterSubmit"
                               @submit="submitHandler"
                               @reject="rejectHandler"
           ></AnnotationRenderer>
+
+
         </b-card>
+
+        <b-button-toolbar v-if="'task_history' in annotationTask" class="mt-4">
+          <b-button-group>
+            <b-button :disabled="!hasPreviousTask()" @click="toPreviousTask" variant="primary" size="sm"
+                      title="Navigate to previous annotation task to modify your previous annotation.">
+              <b-icon-chevron-bar-left></b-icon-chevron-bar-left>
+              Previous task
+            </b-button>
+            <b-button :disabled="!hasNextTask()" @click="toNextTask" variant="primary" size="sm"
+                      title="Navigate to the next annotation task.">
+              Next task
+              <b-icon-chevron-bar-right></b-icon-chevron-bar-right>
+            </b-button>
+            <b-button :disabled="isLatestTask()" @click="toLatestTask" variant="primary" size="sm"
+                      title="Navigate to the current annotation task.">
+              Current task
+              <b-icon-chevron-double-right></b-icon-chevron-double-right>
+            </b-button>
+          </b-button-group>
+        </b-button-toolbar>
+
 
       </div>
       <div v-else>
@@ -143,7 +169,7 @@ import {mapActions, mapState} from "vuex";
 import AnnotationRenderer from "@/components/AnnotationRenderer";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
 import CollapseText from "@/components/CollapseText";
-import {toastError} from "@/utils";
+import {toastError, toastSuccess} from "@/utils";
 import {DocumentType} from '@/enum/DocumentTypes';
 import DeleteModal from "@/components/DeleteModal";
 
@@ -153,26 +179,21 @@ export default {
   components: {DeleteModal, CollapseText, MarkdownRenderer, AnnotationRenderer},
   data() {
     return {
+      clearFormAfterSubmit: true,
       currentTaskIndex: 0,
       annotationTask: null,
+      currentAnnotationTask: null,
       DocumentType,
       showLeaveProjectModal: false,
       showStageIntroCard: false,
       showThankyouCard: false,
     }
   },
-  computed: {
-    currentAnnotationTask(){
-      if( "task_history" in this.annotationTask){
 
-      }
-      else{
-        return this.annotationTask
-      }
-    }
-  },
   methods: {
-    ...mapActions(["getUserAnnotationTask", "completeUserAnnotationTask", "rejectUserAnnotationTask", "annotatorLeaveProject"]),
+    ...mapActions(["getUserAnnotationTask", "getUserAnnotationTaskWithID",
+      "completeUserAnnotationTask", "rejectUserAnnotationTask", "annotatorLeaveProject",
+      "changeAnnotation"]),
     getAnnotationContainerBgClass() {
       return {
         "mt-4": true,
@@ -190,25 +211,101 @@ export default {
       }
 
     },
-    async submitHandler(value, time) {
-      try {
-        await this.completeUserAnnotationTask({
-          annotationID: this.annotationTask.annotation_id,
-          data: value,
-          annotationTime: time,
-        })
-
-      } catch (e) {
-        toastError("Could not get annotation task", e, this)
+    isLatestTask(){
+      return this.currentTaskIndex === 0
+    },
+    // Checks that there is previous task in the task_history
+    hasPreviousTask() {
+      if ("task_history" in this.annotationTask) {
+        return this.currentTaskIndex + 1 < this.annotationTask["task_history"].length
       }
-
-      try {
-        await this.getAnnotationTask()
-      } catch (e) {
-        toastError("Could not get annotation task", e, this)
-      }
+      return false
 
     },
+    // Checks that there is a next task in task_history
+    hasNextTask() {
+      if ("task_history" in this.annotationTask) {
+        return this.currentTaskIndex > 0
+      }
+      return false
+    },
+    // Go to previous task in the history
+    toPreviousTask() {
+      if (this.hasPreviousTask()) {
+        this.currentTaskIndex += 1
+        this.getCurrentTask()
+      }
+    },
+    // Goes to next task in history
+    toNextTask() {
+      if (this.hasNextTask()) {
+        this.currentTaskIndex -= 1
+        this.getCurrentTask()
+      }
+    },
+    // Goes to the latest task
+    toLatestTask() {
+      this.currentTaskIndex = 0
+      this.getCurrentTask()
+    },
+    async getCurrentTask() {
+      try {
+        if ("task_history" in this.annotationTask) {
+          const annotationId = this.annotationTask["task_history"][this.currentTaskIndex]
+          if (annotationId === this.annotationTask.id) {
+            this.currentAnnotationTask = this.annotationTask
+            this.clearFormAfterSubmit = true
+          } else {
+            this.currentAnnotationTask = await this.getUserAnnotationTaskWithID(annotationId)
+            this.clearFormAfterSubmit = false
+          }
+        } else {
+          this.currentAnnotationTask = this.annotationTask
+          this.clearFormAfterSubmit = true
+        }
+
+        //Fills the annotation renderer with data
+        if (this.$refs.annotationRenderer) {
+          this.$refs.annotationRenderer.clearForm()
+          if (this.currentAnnotationTask.annotation_data != null)
+            this.$refs.annotationRenderer.setAnnotationData(this.currentAnnotationTask.annotation_data)
+        }
+
+      } catch (e) {
+        toastError("Could not get annotation task", e, this)
+      }
+    },
+    async submitHandler(value, time) {
+
+      if (this.isLatestTask()) {
+        // Complete a current task
+        try {
+
+          await this.completeUserAnnotationTask({
+            annotationID: this.annotationTask.annotation_id,
+            data: value,
+            annotationTime: time,
+          })
+
+          await this.getAnnotationTask()
+        } catch (e) {
+          toastError("Could not get annotation task", e, this)
+        }
+      } else {
+        // Change a previous annotation task
+        try {
+          await this.changeAnnotation({
+            annotationID: this.currentAnnotationTask.annotation_id,
+            newData: value
+          })
+          toastSuccess("Annotation changed", "Annotation for this document has been successfully changed.")
+        } catch (e) {
+          toastError("Could not  complete annotation task", e, this)
+        }
+
+      }
+    },
+
     async rejectHandler() {
       try {
         await this.rejectUserAnnotationTask(this.annotationTask.annotation_id)
@@ -222,13 +319,16 @@ export default {
         toastError("Could not get annotation task", e, this)
       }
 
-    },
+    }
+    ,
     async getAnnotationTask() {
       try {
 
         const previousTask = this.annotationTask
 
         this.annotationTask = await this.getUserAnnotationTask()
+        this.currentTaskIndex = 0
+        this.getCurrentTask()
 
         // Check that the user has not completed any task in this stage,
         // show intro card
@@ -260,7 +360,8 @@ export default {
         console.log("Still showing error for some reason")
         toastError("Could not get annotation task", e, this)
       }
-    },
+    }
+    ,
     async leaveProjectHandler() {
       try {
         await this.annotatorLeaveProject()


### PR DESCRIPTION
* Added `Annotation.get_annotations_for_user_in_project` to get a list of all completed and pending annotations related to the user in the project that the annotation belongs to
* Added `task_history` in the dict sent to the Annotate view
* Added RPC call `get_annotation_task_with_id` to allow getting previous task
* Added GUI for going to previous annotation, next annotation and current annotation
* Added tests for the model, rpc and integration tests for the above features
