### PR TITLE
resolve #245; separate integration tests to make recording optional

### DIFF
--- a/.github/workflows/integration-tests-cypress-record.yml
+++ b/.github/workflows/integration-tests-cypress-record.yml
@@ -1,13 +1,7 @@
-name: Test image build and run Integration tests
+name: Run integration tests and record to cypress dashboard
 on:
-  push:
-    branches:
-      - master
-      - dev
-  pull_request:
-    branches:
-      - master
-      - dev
+  workflow_dispatch:
+
 
 env:
   MAIN_IMAGE: teamware-main

--- a/.github/workflows/integration-tests-cypress-record.yml
+++ b/.github/workflows/integration-tests-cypress-record.yml
@@ -53,7 +53,9 @@ jobs:
           start: /bin/bash deploy.sh production
           wait-on: 'http://localhost:8076'
           config: baseUrl=http://localhost:8076
-          record: false
+          record: true
         env:
           CYPRESS_TESTENV: ci
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_PROJECT_ID: ${{ secrets.PROJECT_ID }}


### PR DESCRIPTION
Just duplicates the integration tests on github actions so that on pushes/pull requests they run without recording to cypress dashboard but we have a separate workflow for manually triggering the run that records.