### PR TITLE
Upgrade Docker actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,7 +18,7 @@ jobs:
       -
         name: Docker meta (backend)
         id: metaBackend
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/gatenlp/teamware-backend
           tags: |
@@ -28,7 +28,7 @@ jobs:
       -
         name: Docker meta (static files)
         id: metaStatic
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/gatenlp/teamware-static
           tags: |
@@ -37,10 +37,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The current version of the docker build workflow uses outdated versions of the various Docker-related actions which use the [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) "save-state" and "set-output" mechanisms, meaning they will cease to operate after the end of May 2023.  This PR upgrades to new action versions that use the replacement mechanism with `${GITHUB_STATE}` and `${GITHUB_OUTPUT}` files.