### PR TITLE
Allow users to set additional environment variables & gunicorn args when installing with Helm

### DIFF
--- a/charts/gate-teamware/templates/deployment-backend.yaml
+++ b/charts/gate-teamware/templates/deployment-backend.yaml
@@ -42,6 +42,9 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          {{- with .extraArgs }}
+          args: {{- toYaml . | nindent 10 }}
+          {{- end }}
           env:
           - name: DJANGO_SETTINGS_MODULE
             value: teamware.settings.deployment

--- a/charts/gate-teamware/templates/deployment-backend.yaml
+++ b/charts/gate-teamware/templates/deployment-backend.yaml
@@ -129,6 +129,9 @@ spec:
                 key: refresh-token
           {{- end }}{{/* if backend gmail */}}
           {{- end }}{{/* with .Values.email */}}
+          {{- with .extraEnv }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- if and $.Values.email.smtp.security $.Values.email.smtp.clientCertSecret }}
           volumeMounts:
           - name: email-client-cert

--- a/charts/gate-teamware/values.yaml
+++ b/charts/gate-teamware/values.yaml
@@ -81,6 +81,9 @@ backend:
   podSecurityContext: {}
     # fsGroup: 2000
 
+  # extra environment variable settings to be passed to the django container
+  extraEnv: []
+
   securityContext: {}
     # capabilities:
     #   drop:

--- a/charts/gate-teamware/values.yaml
+++ b/charts/gate-teamware/values.yaml
@@ -81,8 +81,9 @@ backend:
   podSecurityContext: {}
     # fsGroup: 2000
 
-  # extra environment variable settings to be passed to the django container
+  # extra environment variable settings and command arguments to be passed to the django container
   extraEnv: []
+  extraArgs: []
 
   securityContext: {}
     # capabilities:


### PR DESCRIPTION
It can be useful to inject additional environment variables to the Django app and/or command line arguments to `gunicorn` (e.g. to override the worker type, timeouts, etc.).  This PR adds slots to the Helm chart to allow this using a custom values file.