### PR TITLE
Fixed `t.currentAnnotationTask is null` error

### DIFF
--- a/frontend/src/views/Annotate.vue
+++ b/frontend/src/views/Annotate.vue
@@ -272,7 +272,7 @@ export default {
         //Fills the annotation renderer with data
         if (this.$refs.annotationRenderer) {
           this.$refs.annotationRenderer.clearForm()
-          if (this.currentAnnotationTask.annotation_data != null)
+          if (this.currentAnnotationTask && this.currentAnnotationTask.annotation_data != null)
             this.$refs.annotationRenderer.setAnnotationData(this.currentAnnotationTask.annotation_data)
         }
 


### PR DESCRIPTION
Resolves #269 

Missed a check to make sure currentAnnotationTask exists before trying to get pre-annotation data inside it. It is now fixed.