### PR TITLE
Dynamic options for checkbox/radio/selector

### DIFF
--- a/docs/docs/manageradminguide/config_examples.js
+++ b/docs/docs/manageradminguide/config_examples.js
@@ -10,12 +10,11 @@ export default {
             "type": "radio",
             "title": "Sentiment",
             "description": "Please select a sentiment of the text above.",
-            "options": {
-                "negative": "Negative",
-                "neutral": "Neutral",
-                "positive": "Positive"
-
-            }
+            "options": [
+                {"value": "negative", "label": "Negative"},
+                {"value": "neutral", "label": "Neutral"},
+                {"value": "positive", "label": "Positive"}
+            ]
         }
     ],
     config2: [
@@ -29,12 +28,11 @@ export default {
             "type": "radio",
             "title": "Sentiment",
             "description": "Please select a sentiment of the text above.",
-            "options": {
-                "negative": "Negative",
-                "neutral": "Neutral",
-                "positive": "Positive"
-
-            }
+            "options": [
+                {"value": "negative", "label": "Negative"},
+                {"value": "neutral", "label": "Neutral"},
+                {"value": "positive", "label": "Positive"}
+            ]
         },
         {
             "name": "opinion",
@@ -201,24 +199,24 @@ export default {
             "name": "radio",
             "type": "radio",
             "title": "Test radio input",
-            "options": {
-                "val1": "Value 1",
-                "val2": "Value 2",
-                "val3": "Value 4",
-                "val4": "Value 5"
-            },
+            "options": [
+                {"value": "val1", "label": "Value 1"},
+                {"value": "val2", "label": "Value 2"},
+                {"value": "val3", "label": "Value 4"},
+                {"value": "val4", "label": "Value 5"}
+            ],
             "description": "Test radio description"
         },
         {
             "name": "checkbox",
             "type": "checkbox",
             "title": "Test checkbox input",
-            "options": {
-                "val1": "Value 1",
-                "val2": "Value 2",
-                "val3": "Value 4",
-                "val4": "Value 5"
-            },
+            "options": [
+                {"value": "val1", "label": "Value 1"},
+                {"value": "val2", "label": "Value 2"},
+                {"value": "val3", "label": "Value 4"},
+                {"value": "val4", "label": "Value 5"}
+            ],
             "description": "Test checkbox description"
         },
         {

--- a/docs/docs/manageradminguide/config_examples.js
+++ b/docs/docs/manageradminguide/config_examples.js
@@ -156,6 +156,32 @@ export default {
         }
     ],
 
+    configDbpediaExample: [
+        {
+            "name": "uri",
+            "type": "radio",
+            "title": "Select the most appropriate URI",
+            "options":[
+                {"fromDocument": "candidates"},
+                {"value": "none", "label": "None of the above"},
+                {"value": "unknown", "label": "Cannot be determined without more context"}
+            ]
+        }
+    ],
+    docDbpediaExample: {
+        "text": "President Bush visited the air base yesterday...",
+        "candidates": [
+            {
+                "value": "http://dbpedia.org/resource/George_W._Bush",
+                "label": "George W. Bush (Jnr)"
+            },
+            {
+                "value": "http://dbpedia.org/resource/George_H._W._Bush",
+                "label": "George H. W. Bush (Snr)"
+            }
+        ]
+    },
+
 
     doc1: {text: "Sometext with <strong>html</strong>"},
     doc2: {

--- a/docs/docs/manageradminguide/config_examples.js
+++ b/docs/docs/manageradminguide/config_examples.js
@@ -62,6 +62,13 @@ export default {
             "text": "Custom field: {{customField}} <br/> Another custom field: {{{anotherCustomField}}} <br/> Subfield: {{{subfield.subfieldContent}}}"
         }
     ],
+    configDisplayPreserveNewlines: [
+        {
+            "name": "htmldisplay",
+            "type": "html",
+            "text": "<div style='white-space: pre-line'>{{text}}</div>"
+        }
+    ],
     configTextInput: [
         {
             "name": "mylabel",
@@ -188,6 +195,9 @@ export default {
         subfield: {
             subfieldContent: "Content of a subfield."
         }
+    },
+    docPlainText: {
+        "text": "This is some text\n\nIt has line breaks that we want to preserve."
     },
     configPreAnnotation: [
         {

--- a/docs/docs/manageradminguide/documents_annotations_management.md
+++ b/docs/docs/manageradminguide/documents_annotations_management.md
@@ -58,24 +58,24 @@ For an example project configuration shown below, there are three captured label
     "name": "radio",
     "type": "radio",
     "title": "Test radio input",
-    "options": {
-      "val1": "Value 1",
-      "val2": "Value 2",
-      "val3": "Value 4",
-      "val4": "Value 5"
-    },
+    "options": [
+      {"value": "val1", "label": "Value 1"},
+      {"value": "val2", "label": "Value 2"},
+      {"value": "val3", "label": "Value 4"},
+      {"value": "val4", "label": "Value 5"}
+    ],
     "description": "Test radio description"
   },
   {
     "name": "checkbox",
     "type": "checkbox",
     "title": "Test checkbox input",
-    "options": {
-      "val1": "Value 1",
-      "val2": "Value 2",
-      "val3": "Value 4",
-      "val4": "Value 5"
-    },
+    "options": [
+      {"value": "val1", "label": "Value 1"},
+      {"value": "val2", "label": "Value 2"},
+      {"value": "val3", "label": "Value 4"},
+      {"value": "val4", "label": "Value 5"}
+    ],
     "description": "Test checkbox description"
   },
   {

--- a/docs/docs/manageradminguide/project_config.md
+++ b/docs/docs/manageradminguide/project_config.md
@@ -68,11 +68,11 @@ of annotation will be collected. Here's an example configuration and a preview o
     "type": "radio",
     "title": "Sentiment",
     "description": "Please select a sentiment of the text above.",
-    "options": {
-      "negative": "Negative",
-      "neutral": "Neutral",
-      "positive": "Positive"
-    }
+    "options": [
+      {"value": "negative", "label": "Negative"},
+      {"value": "neutral", "label": "Neutral"},
+      {"value": "positive", "label": "Positive"}
+    ]
   }
 ]
 ```
@@ -116,12 +116,11 @@ Another field can be added to collect more information, e.g. a text field for op
         "type": "radio",
         "title": "Sentiment",
         "description": "Please select a sentiment of the text above.",
-        "options": {
-            "negative": "Negative",
-            "neutral": "Neutral",
-            "positive": "Positive"
-
-        }
+        "options": [
+            {"value": "negative", "label": "Negative"},
+            {"value": "neutral", "label": "Neutral"},
+            {"value": "positive", "label": "Positive"}
+        ]
     },
     {
         "name": "opinion",

--- a/docs/docs/manageradminguide/project_config.md
+++ b/docs/docs/manageradminguide/project_config.md
@@ -225,6 +225,34 @@ Configuration, showing the same field/column in document as-is or as HTML:
 
 </AnnotationRendererPreview>
 
+If your documents are plain text and include line breaks that need to be preserved when rendering, this can be achieved by using a special HTML wrapper which sets the [`white-space` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space).
+
+<AnnotationRendererPreview :config="configs.configDisplayPreserveNewlines" :document="configs.docPlainText">
+
+**Document**
+
+```json
+{
+    "text": "This is some text\n\nIt has line breaks that we want to preserve."
+}
+```
+
+**Project configuration**
+
+```json
+[
+    {
+        "name": "htmldisplay",
+        "type": "html",
+        "text": "<div style='white-space: pre-line'>{{text}}</div>"
+    }
+]
+```
+
+</AnnotationRendererPreview>
+
+`white-space: pre-line` preserves line breaks but collapses other whitespace down to a single space, `white-space: pre-wrap` would preserve all whitespace including indentation at the start of a line, but would still wrap lines that are too long for the available space.
+
 ### Text input
 
 <AnnotationRendererPreview :config="configs.configTextInput">

--- a/docs/docs/manageradminguide/project_config.md
+++ b/docs/docs/manageradminguide/project_config.md
@@ -346,7 +346,7 @@ Configuration, showing the same field/column in document as-is or as HTML:
 
 </AnnotationRendererPreview>
 
-### Alternative way to provide options for radio, checkbox and selector
+### Alternative way to provide options for radio, checkbox and selector<a id='options-as-dict'></a>
 
 A dictionary (key value pairs) and also be provided to the `options` field of the radio, checkbox and selector widgets
 but note that the ordering of the options are **not guaranteed** as javascript does not sort dictionaries by
@@ -418,7 +418,42 @@ All the examples above have a "static" list of available options for the radio, 
 
 </AnnotationRendererPreview>
 
-`"fromDocument"` is a dot-separated property path leading to the location within each document where the additional options can be found, for example `"fromDocument":"candidates"` looks for a top-level property named `candidates` in each document, `"fromDocument": "options.custom"` would look for a property named `options` which is itself an object with a property named `custom`.  Once the target property is located in the document it is assumed to be the same format as the static `"options"` configuration, i.e. either an array where each element is an object with `value` and `label`, or a dictionary mapping values to labels.  As a convenience for users we also support an array of plain strings, in which case the string will be used as both the value _and_ the label for this option.
+`"fromDocument"` is a dot-separated property path leading to the location within each document where the additional options can be found, for example `"fromDocument":"candidates"` looks for a top-level property named `candidates` in each document, `"fromDocument": "options.custom"` would look for a property named `options` which is itself an object with a property named `custom`.  The target property in the document may be in any of the following forms:
+
+- an array _of objects_, each with `value` and `label` properties, exactly as in the static configuration format - this is the format used in the example above
+- an array _of strings_, where the same string will be used as both the value and the label for that option
+- an arbitrary ["dictionary"](#options-as-dict) object mapping values to labels
+- a _single string_, which is parsed into a list of options
+
+The "single string" alternative is designed to be easier to use when [importing documents](documents_annotations_management.md#importing-documents) from CSV files.  It allows you to provide any number of options in a _single_ CSV column value.  Within the column the options are separated by semicolons, and each option is of the form `value=label`.  Whitespace around the delimiters is ignored, both between options and between the value and label of a single option.  For example given CSV document data of
+
+| text            | options                                           |
+|-----------------|---------------------------------------------------|
+| Favourite fruit | `apple=Apples; orange = Oranges; kiwi=Kiwi fruit` |
+
+a `{"fromDocument": "options"}` configuration would produce the equivalent of
+
+```json
+[
+  {"value": "apple", "label": "Apples"},
+  {"value": "orange", "label": "Oranges"},
+  {"value": "kiwi", "label": "Kiwi fruit"}
+]
+```
+
+If your values or labels may need to contain the default separator characters `;` or `=` you can select different separators by adding extra properties to the configuration:
+
+```json
+{"fromDocument": "options", "separator": "~~", "valueLabelSeparator": "::"}
+```
+
+| text            | options                                              |
+|-----------------|------------------------------------------------------|
+| Favourite fruit | `apple::Apples ~~ orange::Oranges ~~ kiwi::Kiwi fruit` |
+
+The separators can be more than one character, and you can set `"valueLabelSeparator":""` to disable label splitting altogether and just use the value as its own label.
+
+### Mixing static and dynamic options
 
 Static and `fromDocument` options may be freely interspersed in any order, so you can have a fully-dynamic set of options by specifying _only_ a `fromDocument` entry with no static options, or you can have static options that are listed first followed by dynamic options, or dynamic options first followed by static, etc.
 

--- a/docs/docs/manageradminguide/project_config.md
+++ b/docs/docs/manageradminguide/project_config.md
@@ -375,6 +375,52 @@ the order in which keys are added.
 
 </AnnotationRendererPreview>
 
+### Dynamic options for radio, checkbox and selector
+
+All the examples above have a "static" list of available options for the radio, checkbox and selector widgets, where the complete options list is enumerated in the project configuration and every document offers the same set of options.  However it is also possible to take some or all of the options from the _document_ data rather than the _configuration_ data.  For example:
+
+<AnnotationRendererPreview :config="configs.configDbpediaExample" :document="configs.docDbpediaExample">
+
+**Project configuration**
+
+```json
+[
+  {
+    "name": "uri",
+    "type": "radio",
+    "title": "Select the most appropriate URI",
+    "options":[
+      {"fromDocument": "candidates"},
+      {"value": "none", "label": "None of the above"},
+      {"value": "unknown", "label": "Cannot be determined without more context"}
+    ]
+  }
+]
+```
+
+**Document**
+
+```json
+{
+  "text": "President Bush visited the air base yesterday...",
+  "candidates": [
+    {
+      "value": "http://dbpedia.org/resource/George_W._Bush",
+      "label": "George W. Bush (Jnr)"
+    },
+    {
+      "value": "http://dbpedia.org/resource/George_H._W._Bush",
+      "label": "George H. W. Bush (Snr)"
+    }
+  ]
+}
+```
+
+</AnnotationRendererPreview>
+
+`"fromDocument"` is a dot-separated property path leading to the location within each document where the additional options can be found, for example `"fromDocument":"candidates"` looks for a top-level property named `candidates` in each document, `"fromDocument": "options.custom"` would look for a property named `options` which is itself an object with a property named `custom`.  Once the target property is located in the document it is assumed to be the same format as the static `"options"` configuration, i.e. either an array where each element is an object with `value` and `label`, or a dictionary mapping values to labels.  As a convenience for users we also support an array of plain strings, in which case the string will be used as both the value _and_ the label for this option.
+
+Static and `fromDocument` options may be freely interspersed in any order, so you can have a fully-dynamic set of options by specifying _only_ a `fromDocument` entry with no static options, or you can have static options that are listed first followed by dynamic options, or dynamic options first followed by static, etc.
 
 <script>
 import configs from './config_examples';

--- a/examples/documents_radio_fromDocument.json
+++ b/examples/documents_radio_fromDocument.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "1",
+    "text": "What is your favourite fruit?",
+    "choices": [
+      {"value": "apple", "label": "Apple"},
+      {"value": "orange", "label": "Orange"},
+      {"value": "kiwi", "label": "Kiwi fruit"}
+    ]
+  },
+  {
+    "id": "2",
+    "text": "What is your favourite shade of green?",
+    "choices": {
+      "#808000": "Olive",
+      "#80ff00": "Chartreuse",
+      "#98FB98": "Mint"
+    }
+  },
+  {
+    "id": "3",
+    "text": "Which of these languages do you find easiest to speak?",
+    "choices": ["English", "Mandarin", "Portuguese"]
+  },
+  {
+    "id": "4",
+    "text": "What is your preferred computing platform?",
+    "choices": "win=Windows; mac=Apple; linux=Linux (e.g. Ubuntu)"
+  }
+]

--- a/examples/project_config_radio_fromDocument.json
+++ b/examples/project_config_radio_fromDocument.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "question",
+    "type": "html",
+    "title": "Question",
+    "text": "{{text}}"
+  },
+  {
+    "name": "answer",
+    "type": "radio",
+    "title": "Answer",
+    "orientation": "vertical",
+    "options": [
+      {"fromDocument": "choices"},
+      {"value": "none", "label": "No preference"}
+    ]
+  }
+]

--- a/frontend/src/components/JsonEditor.vue
+++ b/frontend/src/components/JsonEditor.vue
@@ -94,18 +94,29 @@ export default {
                           "minItems": 1,
                           "uniqueItems": true,
                           "items": {
-                            "type:": "object",
-                            "properties": {
-                              "label": {"type": "string"},
-                              "value": {
-                                "anyOf": [
-                                  {"type": "string"},
-                                  {"type": "integer"},
-                                  {"type": "number"}
-                                ]
+                            "oneOf": [
+                              {
+                                "type:": "object",
+                                "properties": {
+                                  "label": {"type": "string"},
+                                  "value": {
+                                    "anyOf": [
+                                      {"type": "string"},
+                                      {"type": "integer"},
+                                      {"type": "number"}
+                                    ]
+                                  }
+                                },
+                                "required": ["label", "value"]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "fromDocument": {"type": "string"}
+                                },
+                                "required": ["fromDocument"]
                               }
-                            },
-                            "required": ["label", "value"]
+                            ]
                           }
                         },
                         {

--- a/frontend/src/components/JsonEditor.vue
+++ b/frontend/src/components/JsonEditor.vue
@@ -112,7 +112,9 @@ export default {
                               {
                                 "type": "object",
                                 "properties": {
-                                  "fromDocument": {"type": "string"}
+                                  "fromDocument": {"type": "string"},
+                                  "separator": {"type": "string"},
+                                  "valueLabelSeparator": {"type": "string"}
                                 },
                                 "required": ["fromDocument"]
                               }

--- a/frontend/src/components/annotation/CheckboxInput.vue
+++ b/frontend/src/components/annotation/CheckboxInput.vue
@@ -10,11 +10,11 @@ import InputErrorDisplay from "@/components/annotation/InputErrorDisplay";
 export default {
 name: "CheckboxInput",
   components: {InputErrorDisplay},
-  props: ["value", "config", "state", "msgError", "msgSuccess"],
+  props: ["value", "config", "document", "state", "msgError", "msgSuccess"],
   computed: {
     options(){
       if(this.config && this.config.options){
-        return generateBVOptions(this.config.options)
+        return generateBVOptions(this.config.options, this.document)
       }
       return null
     },

--- a/frontend/src/components/annotation/RadioInput.vue
+++ b/frontend/src/components/annotation/RadioInput.vue
@@ -10,11 +10,11 @@ import InputErrorDisplay from "@/components/annotation/InputErrorDisplay";
 export default {
   name: "RadioInput",
   components: {InputErrorDisplay},
-  props: ["value","config", "state", "msgError", "msgSuccess"],
+  props: ["value","config", "document", "state", "msgError", "msgSuccess"],
   computed: {
     options(){
       if(this.config && this.config.options){
-        return generateBVOptions(this.config.options)
+        return generateBVOptions(this.config.options, this.document)
       }
       return null
     },

--- a/frontend/src/components/annotation/SelectorInput.vue
+++ b/frontend/src/components/annotation/SelectorInput.vue
@@ -11,11 +11,11 @@ import InputErrorDisplay from "@/components/annotation/InputErrorDisplay";
 export default {
   name: "SelectorInput",
   components: {InputErrorDisplay},
-  props: ["value", "config", "state", "msgError", "msgSuccess"],
+  props: ["value", "config", "document", "state", "msgError", "msgSuccess"],
   computed: {
     options(){
       if(this.config && this.config.options){
-        return generateBVOptions(this.config.options)
+        return generateBVOptions(this.config.options, this.document)
       }
       return null
     },

--- a/frontend/src/utils/annotations.js
+++ b/frontend/src/utils/annotations.js
@@ -1,14 +1,37 @@
-export function generateBVOptions(options) {
+import {getValueFromKeyPath} from "@/utils/dict";
+
+export function generateBVOptions(options, document) {
     let optionsList = []
     if (Array.isArray(options)) {
-        for( let i in options){
-            const option = options[i]
-            optionsList.push({
-                value: option.value,
-                text: option.label
-            })
+        for (let option of options){
+            if (document && option && typeof option === "object"
+                && typeof option.fromDocument === "string") {
+                // one or more options taken from the document data
+                const propertyPath = option.fromDocument
+                // fromDocument is supposed to be a dot-separated path, but if
+                // the whole path is found as a top-level property name then use
+                // it, i.e. try opt['foo.bar.baz'] first, then opt.foo.bar.baz
+                // second
+                let propertyValue = (propertyPath in document) ?
+                    document[propertyPath] : getValueFromKeyPath(document, propertyPath);
+                optionsList.push(...generateBVOptions(propertyValue));
+            } else if (option !== null && typeof option !== "undefined") {
+                // single option
+                if (typeof option === 'string') {
+                    optionsList.push({
+                        value: option,
+                        text: option,
+                    })
+                } else if ("value" in option) {
+                    optionsList.push({
+                        value: option.value,
+                        text: ("label" in option ? option.label : option.value),
+                    })
+                } // else invalid option, so ignore
+            }
         }
     } else {
+        // a dictionary mapping value to label
         for (let optionKey in options) {
             optionsList.push({
                 value: optionKey,

--- a/frontend/tests/unit/components/AnnotationRenderer.spec.js
+++ b/frontend/tests/unit/components/AnnotationRenderer.spec.js
@@ -307,6 +307,46 @@ describe("AnnotationRenderer", () => {
 
     })
 
+    it('Test dynamic options fromDocument', async () => {
+        const annotationComps = JSON.parse(fs.readFileSync("../examples/project_config_radio_fromDocument.json", "utf-8"))
+
+        const documents = JSON.parse(fs.readFileSync("../examples/documents_radio_fromDocument.json", "utf-8"))
+
+
+        for(let doc of documents) {
+            const ar = render(AnnotationRenderer, {
+                props: {
+                    config: annotationComps,
+                    document: doc,
+                }
+            })
+            // all example documents have three choices, plus the one static
+            // option from the config should be four radio buttons in total
+            const radios = ar.container.querySelectorAll('input[type=radio]')
+            expect(radios.length).toEqual(4)
+
+            const submitBtn = ar.getByText("Submit")
+            // This is a radio button, so submit before selecting should fail
+            await fireEvent.click(submitBtn)
+            expect(ar.emitted().submit).not.toBeTruthy()
+
+            // but after selecting should succeed
+            await fireEvent.click(radios[0])
+            await fireEvent.click(submitBtn)
+            const submitted = ar.emitted().submit
+            expect(submitted).toBeTruthy()
+
+            // and the selected item ("answer" property of the first argument to the
+            // first emitted "submit" event) should be one of the dynamic ones, not
+            // the static "none"
+            expect(submitted[0][0].answer).not.toEqual("none")
+
+            ar.unmount()
+        }
+
+
+    })
+
     it('Test checkbox minSelected=2 and optional, minSelected should have priority', async () => {
         const annotationComps = [
             {

--- a/frontend/tests/unit/utils/annotations.spec.js
+++ b/frontend/tests/unit/utils/annotations.spec.js
@@ -33,4 +33,39 @@ describe("Annotation utilities", () => {
         }
 
     })
+
+    it("Test generating dynamic options from document", () => {
+        const optionsConfig = [
+            { "value": "fixed1", "label": "Fixed value 1"},
+            { "fromDocument": "options.simple"},
+            { "fromDocument": "options.complex"},
+            { "value": "fixed2", "label": "Fixed value 2"}
+        ]
+
+        const document = {
+            text: "This is an example document",
+            options: {
+                simple: ["Simple value 1", "Simple value 2"],
+                complex: [
+                    {value: "complex1", label: "Complex value 1"},
+                    {value: "complex2", label: "Complex value 2"},
+                ]
+            }
+        }
+
+        let result = generateBVOptions(optionsConfig, document)
+        expect(Array.isArray(result)).toBeTruthy()
+        expect(result.length).toEqual(6)
+        for( let i in result){
+            expect("value" in result[i]).toBeTruthy()
+            expect("text" in result[i]).toBeTruthy()
+        }
+        expect(result.map(v => v.text)).toEqual([
+            "Fixed value 1",
+            "Simple value 1", "Simple value 2",
+            "Complex value 1", "Complex value 2",
+            "Fixed value 2"
+        ])
+
+    })
 })

--- a/frontend/tests/unit/utils/annotations.spec.js
+++ b/frontend/tests/unit/utils/annotations.spec.js
@@ -39,7 +39,8 @@ describe("Annotation utilities", () => {
             { "value": "fixed1", "label": "Fixed value 1"},
             { "fromDocument": "options.simple"},
             { "fromDocument": "options.complex"},
-            { "value": "fixed2", "label": "Fixed value 2"}
+            { "value": "fixed2", "label": "Fixed value 2"},
+            { "fromDocument": "options.delimited", "separator": "###" }
         ]
 
         const document = {
@@ -49,22 +50,35 @@ describe("Annotation utilities", () => {
                 complex: [
                     {value: "complex1", label: "Complex value 1"},
                     {value: "complex2", label: "Complex value 2"},
-                ]
+                ],
+                // delimited options: test that
+                // - whitespace is stripped around delimiters (both between options and between val=text)
+                // - val=text only splits at the first "=", second =-sign is part of the label
+                // - no "=" at all -> whole item is used as both value and text
+                delimited: "delimited1 = Delimited value 1 ###delimited2=Delimited value=2### delimited3 ",
             }
         }
 
         let result = generateBVOptions(optionsConfig, document)
         expect(Array.isArray(result)).toBeTruthy()
-        expect(result.length).toEqual(6)
+        expect(result.length).toEqual(9)
         for( let i in result){
             expect("value" in result[i]).toBeTruthy()
             expect("text" in result[i]).toBeTruthy()
         }
+        expect(result.map(v => v.value)).toEqual([
+            "fixed1",
+            "Simple value 1", "Simple value 2",
+            "complex1", "complex2",
+            "fixed2",
+            "delimited1", "delimited2", "delimited3",
+        ])
         expect(result.map(v => v.text)).toEqual([
             "Fixed value 1",
             "Simple value 1", "Simple value 2",
             "Complex value 1", "Complex value 2",
-            "Fixed value 2"
+            "Fixed value 2",
+            "Delimited value 1", "Delimited value=2", "delimited3",
         ])
 
     })


### PR DESCRIPTION
Implementing a mechanism to take checkbox/radio/selector options from the document as well as from the static project configuration, to allow for things like entity disambiguation tasks where the list of possible options varies from document to document.

The initial implementation is based on a new type of entry in the `options` array, so as well as

```json
{"value": "some-value", "label": "Some value"}
```

we now support

```json
{"fromDocument": "someProperty"}
```

which in turn expects `someProperty` in the document JSON to have the same form as the original `options` configuration itself (either an array of `value`/`label` objects, or a dictionary mapping values to labels).  For convenience I've also added support for an array of plain strings, where a string `"X"` is treated as if it were `{"value": "X", "label": "X"}`.

Closes #289