### PR TITLE
Multi-arch build support

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -16,6 +16,14 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Buildx cache
+        uses: actions/cache@v3
+        with:
+          path: buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('buildx-cache/**') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
         name: Docker meta (backend)
         id: metaBackend
         uses: docker/metadata-action@v4
@@ -57,8 +65,8 @@ jobs:
           push: true
           tags: ${{ steps.metaBackend.outputs.tags }}
           labels: ${{ steps.metaBackend.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=buildx-cache
+          cache-to: type=local,dest=buildx-cache-out,mode=max
           platforms: linux/amd64,linux/arm64
       -
         name: Build and push static files
@@ -69,6 +77,8 @@ jobs:
           push: true
           tags: ${{ steps.metaStatic.outputs.tags }}
           labels: ${{ steps.metaStatic.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=buildx-cache-out
           platforms: linux/amd64,linux/arm64
+      -
+        name: Clean up cache
+        run: rm -rf buildx-cache && mv buildx-cache-out buildx-cache

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -36,6 +36,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       -
+        name: Set up qemu
+        uses: docker/setup-qemu-action@v2
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
@@ -47,7 +50,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push backend
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           target: backend
@@ -56,9 +59,10 @@ jobs:
           labels: ${{ steps.metaBackend.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
       -
         name: Build and push static files
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           target: frontend
@@ -67,3 +71,4 @@ jobs:
           labels: ${{ steps.metaStatic.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/image-build-integration-tests.yml
+++ b/.github/workflows/image-build-integration-tests.yml
@@ -21,6 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Buildx cache
+        uses: actions/cache@v3
+        with:
+          path: buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('buildx-cache/**') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Generate env
         shell: bash
         run: |
@@ -31,18 +42,17 @@ jobs:
 
           # Display the environment variable file for the logs
           cat .env
-
-      - name: Set up Docker cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: integration-test-docker-cache-{hash}
-          restore-keys: |
-            integration-test-docker-cache-
       
-      - uses: docker-practice/actions-setup-docker@master
-      - run: |
+      - name: Build images
+        run: |
+          BUILDX_ARGS_BACKEND="--cache-from type=local,src=buildx-cache --cache-to type=local,dest=buildx-cache-out,mode=max"
+          export BUILDX_ARGS_BACKEND
+          BUILDX_ARGS_FRONTEND="--cache-from type=local,src=buildx-cache-out"
+          export BUILDX_ARGS_FRONTEND
+          
           ./build-images.sh
+          
+          rm -rf buildx-cache && mv buildx-cache-out buildx-cache
           
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/image-tests.yml
+++ b/.github/workflows/image-tests.yml
@@ -38,7 +38,7 @@ jobs:
           cat .env
 
           # Build the test image with npm and pytest installed
-          docker build -t teamware-main:latest --target test .
+          docker buildx build --load -t teamware-main:latest --target test .
 
           # Export the environment variables
           source .env

--- a/.github/workflows/image-tests.yml
+++ b/.github/workflows/image-tests.yml
@@ -14,13 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Docker cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Buildx cache
+        uses: actions/cache@v3
         with:
-          key: unit-test-docker-cache-{hash}
+          path: buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('buildx-cache/**') }}
           restore-keys: |
-            unit-test-docker-cache-
+            ${{ runner.os }}-buildx-
 
       - name: Run the backend and frontend tests in containers
         run: |
@@ -38,7 +41,10 @@ jobs:
           cat .env
 
           # Build the test image with npm and pytest installed
-          docker buildx build --load -t teamware-main:latest --target test .
+          docker buildx build --cache-from type=local,src=buildx-cache --cache-to type=local,dest=buildx-cache-out,mode=max --load -t teamware-main:latest --target test .
+          
+          # Clear up the cache
+          rm -rf buildx-cache && mv buildx-cache-out buildx-cache
 
           # Export the environment variables
           source .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14-buster-slim as nodebuilder
+# Node build currently only works on amd64
+FROM --platform=linux/amd64 node:14-buster-slim as nodebuilder
 RUN mkdir /app/
 WORKDIR /app/
 COPY package.json package-lock.json ./
@@ -9,11 +10,12 @@ RUN npm run build
 
 
 FROM python:3.9-slim-buster AS backend
+ARG TARGETARCH
 ENV PYTHONUNBUFFERED 1
 RUN apt-get --allow-releaseinfo-change update && \
     apt-get -y install gcc libpq-dev libmagic1 postgresql-client && \
     rm -rf /var/lib/apt/lists/*
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /sbin/tini
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH /sbin/tini
 RUN addgroup --gid 1001 "gate" && \
       adduser --disabled-password --gecos "GATE User,,," \
         --home /app --ingroup gate --uid 1001 gate && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -7,6 +7,6 @@ set -o allexport
 source .env
 set +o allexport
 
-docker buildx build --load -t $IMAGE_REGISTRY$MAIN_IMAGE:$IMAGE_TAG --target backend .
+docker buildx build $BUILDX_ARGS_BACKEND --load -t $IMAGE_REGISTRY$MAIN_IMAGE:$IMAGE_TAG --target backend .
 
-docker buildx build --load -t $IMAGE_REGISTRY$STATIC_IMAGE:$IMAGE_TAG --target frontend .
+docker buildx build $BUILDX_ARGS_FRONTEND --load -t $IMAGE_REGISTRY$STATIC_IMAGE:$IMAGE_TAG --target frontend .

--- a/build-images.sh
+++ b/build-images.sh
@@ -7,6 +7,6 @@ set -o allexport
 source .env
 set +o allexport
 
-docker build -t $IMAGE_REGISTRY$MAIN_IMAGE:$IMAGE_TAG --target backend .
+docker buildx build --load -t $IMAGE_REGISTRY$MAIN_IMAGE:$IMAGE_TAG --target backend .
 
-docker build -t $IMAGE_REGISTRY$STATIC_IMAGE:$IMAGE_TAG --target frontend .
+docker buildx build --load -t $IMAGE_REGISTRY$STATIC_IMAGE:$IMAGE_TAG --target frontend .


### PR DESCRIPTION
Build multi-arch Docker images that will run natively on ARM64 (e.g. Mac M1, AWS Graviton) as well as on Intel/AMD.  For now the `nodebuilder` stage is hard-coded to always run as `amd64` due to #304 but the final images are native `arm64`.

This requires changes to the `Dockerfile` that mean it is now only buildable using `docker buildx build`, not the legacy `docker build` builder.