### PR TITLE
Don't redeploy docs on push to master

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,6 @@ name: Build and deploy documentation
 on:
   push:
     branches:
-      - master
       - dev
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Since in normal circumstances the master branch should only advance via PRs from dev, there is no need to re-deploy the docs on pushes to master.  At _best_, a deploy from master will be identical to the latest deploy from dev, at _worst_ (if we deploy a hotfix to master without going through dev first) the master deploy will overwrite the latest dev docs with an earlier version and leave the published docs out of date with respect to the latest dev code.

This happened yesterday (2023-03-09) with the merge of #310, which deleted the privacy policy section from the development docs - I've since manually re-run the `documentation.yml` workflow on dev to re-instate the correct version.