### PR TITLE
add doi to citation file and doi badge

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,3 +33,7 @@ title: GATE Teamware
 type: software
 url: https://gatenlp.github.io/gate-teamware/
 version: 0.4.0
+identifiers:
+  - description: The collection of archived snapshots of all versions of GATE Teamware 2
+    type: doi
+    value: "10.5281/zenodo.7821718"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GATE Teamware
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7821718.svg)](https://doi.org/10.5281/zenodo.7821718)
-
 ![](/frontend/public/static/img/gate-teamware-logo.svg "GATE Teamware")
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7821718.svg)](https://doi.org/10.5281/zenodo.7821718)
 
 A web application for collaborative document annotation. 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GATE Teamware
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7821718.svg)](https://doi.org/10.5281/zenodo.7821718)
+
 ![](/frontend/public/static/img/gate-teamware-logo.svg "GATE Teamware")
 
 A web application for collaborative document annotation. 


### PR DESCRIPTION
This adds the doi for the collection of all versions of Teamware on Zenodo. The doi will always render to the latest version on Zenodo.