### PR TITLE
add logging and alter data type for telemetry

### DIFF
--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -21,7 +21,7 @@ class TestTelemetrySender(TestCase):
 
         proj = Project.objects.first()
 
-        ts = TelemetrySender("completed", {})
+        ts = TelemetrySender("completed", { 'uuid': 'mock-uuid'})
 
         mocker.post(ts.url, status_code=201) # set up mocker for http post request
         ts.send()

--- a/backend/utils/telemetry.py
+++ b/backend/utils/telemetry.py
@@ -1,9 +1,11 @@
 import json
+import logging
 from threading import Thread
 import requests
 from urllib.parse import urljoin
 from django.conf import settings
 
+log = logging.getLogger(__name__)
 class TelemetrySender:
 
     def __init__(self, status: str, data: dict) -> None:
@@ -20,7 +22,11 @@ class TelemetrySender:
         if settings.TELEMETRY_ON:
             self.thread = Thread(target=self._post_request)
             self.thread.run()
+        else:
+            log.info(f"Telemetry is switched off. Not sending telemetry data for project {self.data['uuid']}.")
         
     def _post_request(self):
-        r = requests.post(self.url, data=json.dumps(self.data))
+        log.info(f"Sending telemetry data for project {self.data['uuid']} to {self.url}.")
+        r = requests.post(self.url, data=self.data)
         self.http_status_code = r.status_code
+        log.info(f"{self.http_status_code}: {r.text}")

--- a/backend/utils/telemetry.py
+++ b/backend/utils/telemetry.py
@@ -27,6 +27,6 @@ class TelemetrySender:
         
     def _post_request(self):
         log.info(f"Sending telemetry data for project {self.data['uuid']} to {self.url}.")
-        r = requests.post(self.url, data=self.data)
+        r = requests.post(self.url, json=self.data)
         self.http_status_code = r.status_code
         log.info(f"{self.http_status_code}: {r.text}")


### PR DESCRIPTION
Turns out that telemetry was not working..
This PR adds some logging and passes in data as ~a dict~ json to set the ContentType correctly as `application/json`?

~Other concurrent fixes are happening on the server end here https://github.com/GateNLP/telemetry-server/pull/3~