### PR TITLE
Fix for documentation build breaking

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           npm install
+          npm run install:docs
           npm run build:docs
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.0.0


### PR DESCRIPTION
Documentation's dependencies has to be installed separately after isolating documentation build chain. 