### PR TITLE
Implement conditional widgets

### DIFF
--- a/docs/docs/.vuepress/components/AnnotationRendererPreview.vue
+++ b/docs/docs/.vuepress/components/AnnotationRendererPreview.vue
@@ -7,11 +7,15 @@
 
       </b-tab>
       <b-tab title="Preview">
+        <p v-if="documents.length > 1">Document {{documentIndex + 1}} of {{documents.length}}</p>
         <b-card class="mb-2 mt-2">
-          <AnnotationRenderer :config="config"
-                              :document="document" :allow_document_reject="true"
+          <AnnotationRenderer ref="annotationRenderer"
+                              :config="config"
+                              :document="currentDocument" :allow_document_reject="true"
                               v-model="annotationOutput"
                               :doc_preannotation_field="preAnnotation"
+                              @submit="nextDocument()"
+                              @reject="nextDocument()"
           ></AnnotationRenderer>
         </b-card>
         <b-card class="mb-2 mt-2">
@@ -35,10 +39,22 @@ export default {
   },
   data(){
     return {
-      annotationOutput: {}
-
+      annotationOutput: {},
+      documentIndex: 0
     }
 
+  },
+  computed: {
+    documents() {
+      if(Array.isArray(this.document)) {
+        return this.document
+      } else {
+        return [this.document]
+      }
+    },
+    currentDocument() {
+      return this.documents[this.documentIndex]
+    }
   },
   props: {
     preAnnotation: {
@@ -74,6 +90,12 @@ export default {
           ]
       }
     },
+  },
+  methods: {
+    nextDocument() {
+      this.documentIndex = (this.documentIndex + 1) % this.documents.length;
+      this.$refs.annotationRenderer.clearForm()
+    }
   }
 }
 </script>

--- a/docs/docs/manageradminguide/config_examples.js
+++ b/docs/docs/manageradminguide/config_examples.js
@@ -204,6 +204,26 @@ export default {
         ]
     },
 
+    configConditional1: [
+        {
+            "name": "uri",
+            "type": "radio",
+            "title": "Select the most appropriate URI",
+            "options":[
+                {"fromDocument": "candidates"},
+                {"value": "other", "label": "Other"}
+            ]
+        },
+        {
+            "name": "otherValue",
+            "type": "text",
+            "title": "Please specify another value",
+            "if": "annotation.uri == 'other'",
+            "regex": "^(https?|urn):",
+            "valError": "Please specify a URI (starting http:, https: or urn:)"
+        }
+    ],
+
 
     doc1: {text: "Sometext with <strong>html</strong>"},
     doc2: {

--- a/docs/docs/manageradminguide/config_examples.js
+++ b/docs/docs/manageradminguide/config_examples.js
@@ -223,6 +223,50 @@ export default {
             "valError": "Please specify a URI (starting http:, https: or urn:)"
         }
     ],
+    configConditional2: [
+        {
+            "name": "htmldisplay",
+            "type": "html",
+            "text": "{{{text}}}"
+        },
+        {
+            "name": "sentiment",
+            "type": "radio",
+            "title": "Sentiment",
+            "description": "Please select a sentiment of the text above.",
+            "options": [
+                {"value": "negative", "label": "Negative"},
+                {"value": "neutral", "label": "Neutral"},
+                {"value": "positive", "label": "Positive"}
+            ]
+        },
+        {
+            "name": "reason",
+            "type": "text",
+            "title": "Why do you disagree with the suggested value?",
+            "if": "annotation.sentiment !== document.preanno.sentiment"
+        }
+    ],
+    docsConditional2: [
+        {
+            "text": "I love the thing!",
+            "preanno": {
+                "sentiment": "positive"
+            }
+        },
+        {
+            "text": "I hate the thing!",
+            "preanno": {
+                "sentiment": "negative"
+            }
+        },
+        {
+            "text": "The thing is ok, I guess...",
+            "preanno": {
+                "sentiment": "neutral"
+            }
+        }
+    ],
 
 
     doc1: {text: "Sometext with <strong>html</strong>"},

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,8 +9,13 @@
       "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
+        "@jsep-plugin/numbers": "^1.0.1",
+        "@jsep-plugin/object": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "@jsep-plugin/spread": "^1.0.2",
         "bootstrap": "^4.6.1",
         "bootstrap-vue": "^2.21.2",
+        "jse-eval": "^1.5.2",
         "mustache": "^4.2.0",
         "npm-run-all": "^4.1.5"
       },
@@ -1855,6 +1860,50 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/numbers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/numbers/-/numbers-1.0.1.tgz",
+      "integrity": "sha512-SdZgumrnEKcKSr1IA+yHY9RXwnGFO8BBh3hXHKxJUIodEsl1tFrKtapHGKtbi2jSX9RIig9sfumNJfI1/MYHng==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/object": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/object/-/object-1.2.1.tgz",
+      "integrity": "sha512-6YoZP80h2QFCuxyqj+OvoqEnTu2r5cSRpgpvGauWlvnevFP/F/dibpvXDpnHeqwT2FIzzvg47YOe3QD/UT8vJw==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/spread": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/spread/-/spread-1.0.2.tgz",
+      "integrity": "sha512-yYUYcgfWnttw1QSwEu4PDDRKw/iT/BJcBhnDkxEuJOBmMa+W/PTNETBM9aoBEEglkYDAaprp58DYlU5stKCbFg==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
@@ -9339,6 +9388,22 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "node_modules/jse-eval": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/jse-eval/-/jse-eval-1.5.2.tgz",
+      "integrity": "sha512-o2Uc6F5CnfXTx5l+BRWSSBr4e8cNgebuxAaIQghKqk6cda0TazUDf/1Y/KhjWHN6xptnaQA3cZxhvYVSJca/YQ==",
+      "dependencies": {
+        "jsep": "^1.2.0"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
+      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -14516,6 +14581,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -14586,15 +14660,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-ansi": {
@@ -18323,6 +18388,30 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "@jsep-plugin/numbers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/numbers/-/numbers-1.0.1.tgz",
+      "integrity": "sha512-SdZgumrnEKcKSr1IA+yHY9RXwnGFO8BBh3hXHKxJUIodEsl1tFrKtapHGKtbi2jSX9RIig9sfumNJfI1/MYHng==",
+      "requires": {}
+    },
+    "@jsep-plugin/object": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/object/-/object-1.2.1.tgz",
+      "integrity": "sha512-6YoZP80h2QFCuxyqj+OvoqEnTu2r5cSRpgpvGauWlvnevFP/F/dibpvXDpnHeqwT2FIzzvg47YOe3QD/UT8vJw==",
+      "requires": {}
+    },
+    "@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "requires": {}
+    },
+    "@jsep-plugin/spread": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/spread/-/spread-1.0.2.tgz",
+      "integrity": "sha512-yYUYcgfWnttw1QSwEu4PDDRKw/iT/BJcBhnDkxEuJOBmMa+W/PTNETBM9aoBEEglkYDAaprp58DYlU5stKCbFg==",
+      "requires": {}
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -24275,6 +24364,19 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "jse-eval": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/jse-eval/-/jse-eval-1.5.2.tgz",
+      "integrity": "sha512-o2Uc6F5CnfXTx5l+BRWSSBr4e8cNgebuxAaIQghKqk6cda0TazUDf/1Y/KhjWHN6xptnaQA3cZxhvYVSJca/YQ==",
+      "requires": {
+        "jsep": "^1.2.0"
+      }
+    },
+    "jsep": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
+      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ=="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -28461,6 +28563,15 @@
       "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -28510,15 +28621,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "create_version": "node manage_versions.js create $npm_package_version",
-    "serve": "vuepress dev docs",
+    "serve": "NODE_OPTIONS=--openssl-legacy-provider vuepress dev docs",
     "build": "NODE_OPTIONS=--openssl-legacy-provider node manage_versions.js build"
   },
   "repository": {
@@ -23,8 +23,13 @@
     "vuepress": "^1.8.2"
   },
   "dependencies": {
+    "@jsep-plugin/numbers": "^1.0.1",
+    "@jsep-plugin/object": "^1.2.1",
+    "@jsep-plugin/regex": "^1.0.3",
+    "@jsep-plugin/spread": "^1.0.2",
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.21.2",
+    "jse-eval": "^1.5.2",
     "mustache": "^4.2.0",
     "npm-run-all": "^4.1.5"
   }

--- a/examples/project_config_conditional.json
+++ b/examples/project_config_conditional.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "Document",
+    "text": "{{{text}}}",
+    "type": "html"
+  },
+  {
+    "name": "sentiment",
+    "type": "radio",
+    "title": "Sentiment",
+    "options": [
+      {"value": "negative", "label":"Negative", "helptext": "some example help text"},
+      {"value": "neutral", "label":"Neutral"},
+      {"value": "positive", "label":"Positive"}
+    ]
+  },
+  {
+    "if": "'sentiment' in document.preanno && annotation.sentiment !== document.preanno.sentiment",
+    "name": "reason",
+    "type": "text",
+    "title": "Why?",
+    "description": "Why do you disagree with the original suggestion?"
+  },
+  {
+    "type": "radio",
+    "title": "Confidence",
+    "description": "How confident are you in your choice?",
+    "name": "confidence",
+    "options": [
+      {"value": "1", "label": "1 (Not at all)"},
+      {"value": "2", "label": "2"},
+      {"value": "3", "label": "3"},
+      {"value": "4", "label": "4"},
+      {"value": "5", "label": "5 (dead certain)"}
+    ]
+  },
+  {
+    "if": "annotation.confidence && annotation.confidence < 4",
+    "name": "confidence_reason",
+    "type": "text",
+    "title": "What makes you unsure?"
+  }
+]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,6 @@
       "name": "frontend",
       "version": "2.0.0",
       "dependencies": {
-        "@jsep-plugin/arrow": "^1.0.5",
-        "@jsep-plugin/new": "^1.0.3",
         "@jsep-plugin/numbers": "^1.0.1",
         "@jsep-plugin/object": "^1.2.1",
         "@jsep-plugin/regex": "^1.0.3",
@@ -676,28 +674,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
-      }
-    },
-    "node_modules/@jsep-plugin/arrow": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/arrow/-/arrow-1.0.5.tgz",
-      "integrity": "sha512-4Q9/6nETEf79DQdyynPk9G5CvYGw/TyRAw6IpkiIBm1z6eyDyjhcLjYxmBCqlKIUvjS8h8hfU8MzSjQRSntK5Q==",
-      "engines": {
-        "node": ">= 10.16.0"
-      },
-      "peerDependencies": {
-        "jsep": "^0.4.0||^1.0.0"
-      }
-    },
-    "node_modules/@jsep-plugin/new": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/new/-/new-1.0.3.tgz",
-      "integrity": "sha512-TsXGyHeK8yKinrNXirljPvbEVth/3YIFH7oufq2E96CAuRzxYS9jEOA0u9/kVe5su1RBzTJMXG+jlWZ4gwLMiQ==",
-      "engines": {
-        "node": ">= 10.16.0"
-      },
-      "peerDependencies": {
-        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@jsep-plugin/numbers": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,12 @@
       "name": "frontend",
       "version": "2.0.0",
       "dependencies": {
+        "@jsep-plugin/arrow": "^1.0.5",
+        "@jsep-plugin/new": "^1.0.3",
+        "@jsep-plugin/numbers": "^1.0.1",
+        "@jsep-plugin/object": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "@jsep-plugin/spread": "^1.0.2",
         "@vitejs/plugin-vue2": "^2.2.0",
         "axios": "^0.21.1",
         "bootstrap": "^4.6.0",
@@ -17,6 +23,7 @@
         "css-loader": "^5.2.1",
         "csvtojson": "^2.0.10",
         "js-cookie": "^2.2.1",
+        "jse-eval": "^1.5.2",
         "jsonl-parse-stringify": "^1.0.1",
         "jszip": "^3.7.1",
         "lodash": "^4.17.21",
@@ -353,6 +360,72 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/arrow": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/arrow/-/arrow-1.0.5.tgz",
+      "integrity": "sha512-4Q9/6nETEf79DQdyynPk9G5CvYGw/TyRAw6IpkiIBm1z6eyDyjhcLjYxmBCqlKIUvjS8h8hfU8MzSjQRSntK5Q==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/new": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/new/-/new-1.0.3.tgz",
+      "integrity": "sha512-TsXGyHeK8yKinrNXirljPvbEVth/3YIFH7oufq2E96CAuRzxYS9jEOA0u9/kVe5su1RBzTJMXG+jlWZ4gwLMiQ==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/numbers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/numbers/-/numbers-1.0.1.tgz",
+      "integrity": "sha512-SdZgumrnEKcKSr1IA+yHY9RXwnGFO8BBh3hXHKxJUIodEsl1tFrKtapHGKtbi2jSX9RIig9sfumNJfI1/MYHng==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/object": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/object/-/object-1.2.1.tgz",
+      "integrity": "sha512-6YoZP80h2QFCuxyqj+OvoqEnTu2r5cSRpgpvGauWlvnevFP/F/dibpvXDpnHeqwT2FIzzvg47YOe3QD/UT8vJw==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/spread": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/spread/-/spread-1.0.2.tgz",
+      "integrity": "sha512-yYUYcgfWnttw1QSwEu4PDDRKw/iT/BJcBhnDkxEuJOBmMa+W/PTNETBM9aoBEEglkYDAaprp58DYlU5stKCbFg==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@kurkle/color": {
@@ -3501,6 +3574,19 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4524,6 +4610,22 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jse-eval": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/jse-eval/-/jse-eval-1.5.2.tgz",
+      "integrity": "sha512-o2Uc6F5CnfXTx5l+BRWSSBr4e8cNgebuxAaIQghKqk6cda0TazUDf/1Y/KhjWHN6xptnaQA3cZxhvYVSJca/YQ==",
+      "dependencies": {
+        "jsep": "^1.2.0"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
+      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==",
+      "engines": {
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/json-parse-even-better-errors": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
         "@vitest/coverage-c8": "^0.30.1",
         "@vue/test-utils": "^1.0.3",
         "cypress": "^12.9.0",
+        "esbuild": "^0.17.18",
         "vitest": "^0.30.1"
       }
     },
@@ -275,16 +276,331 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
+      "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
+      "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
+      "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
+      "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
+      "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
+      "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
+      "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
+      "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
+      "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
+      "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
+      "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
+      "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
+      "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
+      "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
+      "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.15.tgz",
-      "integrity": "sha512-JsdS0EgEViwuKsw5tiJQo9UdQdUJYuB+Mf6HxtJSPN35vez1hlrNb1KajvKWF5Sa35j17+rW1ECEO9iNrIXbNg==",
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
+      "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
       "cpu": [
         "x64"
       ],
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
+      "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
+      "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
+      "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
+      "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
+      "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
+      "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -3155,9 +3471,9 @@
       "peer": true
     },
     "node_modules/esbuild": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.15.tgz",
-      "integrity": "sha512-LBUV2VsUIc/iD9ME75qhT4aJj0r75abCVS0jakhFzOtR7TQsqQA5w0tZ+KTKnwl3kXE0MhskNdHDh/I5aCR1Zw==",
+      "version": "0.17.18",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
+      "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -3166,28 +3482,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.15",
-        "@esbuild/android-arm64": "0.17.15",
-        "@esbuild/android-x64": "0.17.15",
-        "@esbuild/darwin-arm64": "0.17.15",
-        "@esbuild/darwin-x64": "0.17.15",
-        "@esbuild/freebsd-arm64": "0.17.15",
-        "@esbuild/freebsd-x64": "0.17.15",
-        "@esbuild/linux-arm": "0.17.15",
-        "@esbuild/linux-arm64": "0.17.15",
-        "@esbuild/linux-ia32": "0.17.15",
-        "@esbuild/linux-loong64": "0.17.15",
-        "@esbuild/linux-mips64el": "0.17.15",
-        "@esbuild/linux-ppc64": "0.17.15",
-        "@esbuild/linux-riscv64": "0.17.15",
-        "@esbuild/linux-s390x": "0.17.15",
-        "@esbuild/linux-x64": "0.17.15",
-        "@esbuild/netbsd-x64": "0.17.15",
-        "@esbuild/openbsd-x64": "0.17.15",
-        "@esbuild/sunos-x64": "0.17.15",
-        "@esbuild/win32-arm64": "0.17.15",
-        "@esbuild/win32-ia32": "0.17.15",
-        "@esbuild/win32-x64": "0.17.15"
+        "@esbuild/android-arm": "0.17.18",
+        "@esbuild/android-arm64": "0.17.18",
+        "@esbuild/android-x64": "0.17.18",
+        "@esbuild/darwin-arm64": "0.17.18",
+        "@esbuild/darwin-x64": "0.17.18",
+        "@esbuild/freebsd-arm64": "0.17.18",
+        "@esbuild/freebsd-x64": "0.17.18",
+        "@esbuild/linux-arm": "0.17.18",
+        "@esbuild/linux-arm64": "0.17.18",
+        "@esbuild/linux-ia32": "0.17.18",
+        "@esbuild/linux-loong64": "0.17.18",
+        "@esbuild/linux-mips64el": "0.17.18",
+        "@esbuild/linux-ppc64": "0.17.18",
+        "@esbuild/linux-riscv64": "0.17.18",
+        "@esbuild/linux-s390x": "0.17.18",
+        "@esbuild/linux-x64": "0.17.18",
+        "@esbuild/netbsd-x64": "0.17.18",
+        "@esbuild/openbsd-x64": "0.17.18",
+        "@esbuild/sunos-x64": "0.17.18",
+        "@esbuild/win32-arm64": "0.17.18",
+        "@esbuild/win32-ia32": "0.17.18",
+        "@esbuild/win32-x64": "0.17.18"
       }
     },
     "node_modules/escalade": {
@@ -6357,6 +6673,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6369,14 +6693,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-ansi": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,6 @@
     "test": "run-s test:unit test:component"
   },
   "dependencies": {
-    "@jsep-plugin/arrow": "^1.0.5",
-    "@jsep-plugin/new": "^1.0.3",
     "@jsep-plugin/numbers": "^1.0.1",
     "@jsep-plugin/object": "^1.2.1",
     "@jsep-plugin/regex": "^1.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,8 +50,9 @@
     "@testing-library/vue": "^5.6.2",
     "@vitest/coverage-c8": "^0.30.1",
     "@vue/test-utils": "^1.0.3",
-    "vitest": "^0.30.1",
-    "cypress": "^12.9.0"
+    "cypress": "^12.9.0",
+    "esbuild": "^0.17.18",
+    "vitest": "^0.30.1"
   },
   "browserslist": [
     "> 1%",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,12 @@
     "test": "run-s test:unit test:component"
   },
   "dependencies": {
+    "@jsep-plugin/arrow": "^1.0.5",
+    "@jsep-plugin/new": "^1.0.3",
+    "@jsep-plugin/numbers": "^1.0.1",
+    "@jsep-plugin/object": "^1.2.1",
+    "@jsep-plugin/regex": "^1.0.3",
+    "@jsep-plugin/spread": "^1.0.2",
     "@vitejs/plugin-vue2": "^2.2.0",
     "axios": "^0.21.1",
     "bootstrap": "^4.6.0",
@@ -22,6 +28,7 @@
     "css-loader": "^5.2.1",
     "csvtojson": "^2.0.10",
     "js-cookie": "^2.2.1",
+    "jse-eval": "^1.5.2",
     "jsonl-parse-stringify": "^1.0.1",
     "jszip": "^3.7.1",
     "lodash": "^4.17.21",

--- a/frontend/src/components/AnnotationRenderer.vue
+++ b/frontend/src/components/AnnotationRenderer.vue
@@ -222,7 +222,7 @@ export default {
       this.validationErrorMsg = {}
 
 
-      for (let elemConfig of this.config) {
+      for (let elemConfig of this.shownElements) {
 
         const elemName = elemConfig.name
         const elemType = elemConfig.type

--- a/frontend/src/components/AnnotationRenderer.vue
+++ b/frontend/src/components/AnnotationRenderer.vue
@@ -46,31 +46,7 @@ import {DocumentType} from '@/enum/DocumentTypes';
 import MarkdownRenderer from "@/components/MarkdownRenderer.vue";
 import _ from "lodash"
 import {getValueFromKeyPath} from "@/utils/dict";
-import {compile, registerPlugin} from "jse-eval";
-
-// set up jsep extensions
-// arrow functions, to allow things like "annotations.myCheckboxes.some(v => v < 4)"
-// to test multi-select checkboxes
-import jsepArrow from "@jsep-plugin/arrow";
-// new operator to allow for date comparisons with "new Date()" or similar
-import jsepNew from "@jsep-plugin/new";
-// hex and octal numeric literals
-import jsepNumbers from "@jsep-plugin/numbers";
-// object expressions
-import jsepObject from "@jsep-plugin/object";
-// regex support, to allow for if tests that check a text field against a regex
-import jsepRegex from "@jsep-plugin/regex";
-// destructuring, useful in filtering functions etc.
-import jsepSpread from "@jsep-plugin/spread";
-
-registerPlugin(
-    jsepArrow,
-    jsepNew,
-    jsepNumbers,
-    jsepObject,
-    jsepRegex,
-    jsepSpread,
-)
+import {compile} from "@/utils/expressions"
 
 /**
  * Renders annotation display and input capture from the config property
@@ -155,17 +131,12 @@ export default {
       if (!this.config) {
         return [];
       }
-      const exprContext = {
-        document: this.document,
-        annotation: this.annotationData,
-        // add useful JS functions to the context
-        String, Object, Array, Date, RegExp,
-        JSON, Math, parseInt, parseFloat,
-        encodeURIComponent, decodeURIComponent
-      };
       return this.config.filter((elemConfig, i) => {
         try {
-          return !!this.conditions[i](exprContext);
+          return this.conditions[i]({
+            document: this.document,
+            annotation: this.annotationData,
+          });
         } catch (_) {
           // treat error as "don't show"
           return false;

--- a/frontend/src/components/JsonEditor.vue
+++ b/frontend/src/components/JsonEditor.vue
@@ -32,7 +32,8 @@ export default {
               "description": {"type": "string"},
               "optional": {"type": "boolean"},
               "valSuccess": {"type": "string"},
-              "valError": {"type": "string"}
+              "valError": {"type": "string"},
+              "if": {"type": "string"}
             },
             "allOf": [
               {

--- a/frontend/src/components/ProjectConfiguration.vue
+++ b/frontend/src/components/ProjectConfiguration.vue
@@ -169,6 +169,7 @@
             <AnnotationRenderer :config="local_project.configuration"
                                 :doc_preannotation_field="local_project.document_pre_annotation_field"
                                 :document="previewDocument"
+                                :show_expression_errors="true"
                                 data-cy="annotation-renderer"
                                 @input="annotationOutputHandler"
             ></AnnotationRenderer>

--- a/frontend/src/utils/expressions.js
+++ b/frontend/src/utils/expressions.js
@@ -1,0 +1,214 @@
+import ExpressionEval from "jse-eval";
+
+// set up jsep extensions
+// hex and octal numeric literals
+import jsepNumbers from "@jsep-plugin/numbers";
+// object expressions
+import jsepObject from "@jsep-plugin/object";
+// regex literal support
+import jsepRegex from "@jsep-plugin/regex";
+// destructuring, useful in filtering functions etc.
+import jsepSpread from "@jsep-plugin/spread";
+
+ExpressionEval.registerPlugin(
+    jsepNumbers,
+    jsepObject,
+    jsepRegex,
+    jsepSpread,
+)
+
+// add "in" as a binary operator, partly to make it work in the syntax of all(x in xs, ...)
+// expressions but also in its own right as a real binary operator.  "A in B" behaves like
+// B.includes(A) if B is an array, otherwise it mean the same as the normal Javascript
+// "A in B" checking whether B has a property named (the result of evaluating) A
+function inOperator(a, b) {
+    if(Array.isArray(b)) {
+        return b.includes(a)
+    } else {
+        return a in b
+    }
+}
+ExpressionEval.addBinaryOp("in", 6, inOperator)
+
+// add =~ binary operator that tests a string against a regex
+function testRegex(a, b) {
+    if (!(b instanceof RegExp)) {
+        throw new Error("Right hand argument of =~ must be a regular expression")
+    }
+    return b.test(a)
+}
+ExpressionEval.addBinaryOp("=~", 4, testRegex)
+
+// Monkey-patch ExpressionEval to forbid access to the __ob__ property
+// (which otherwise provides a route to reach the global "window" object)
+// and any property whose name begins with "$", as well as the usual
+// prototype and constructor properties that are forbidden by default.
+//
+// Within the body of the function, "this" refers to the
+// ExpressionEval instance that is evaluating the expression, so it can
+// access other instance methods of that class.
+function evaluateMemberExcludeUnsafe(node) {
+    return this.eval(node.object, (object) => this
+        .evalSyncAsync(
+            node.computed
+                ? this.eval(node.property)
+                : node.property.name,
+            (key) => {
+                if (typeof key === 'string' && /^\$|^(?:__proto__|prototype|constructor|__ob__)$/.test(key)) {
+                    throw Error(`Access to member "${key}" disallowed.`);
+                }
+                return [object, (node.optional ? (object || {}) : object)[key], key];
+            })
+    );
+}
+ExpressionEval.prototype.evaluateMember = evaluateMemberExcludeUnsafe;
+
+// similarly, replace the "Identifier" evaluator with one that checks the same block-list
+function evalIdentifierExcludeUnsafe(node) {
+    const key = node.name;
+    if (typeof key === 'string' && /^\$|^(?:__proto__|prototype|constructor|__ob__)$/.test(key)) {
+        throw Error(`Access to member "${key}" disallowed.`);
+    }
+    return this.context[key]
+}
+ExpressionEval.addEvaluator("Identifier", evalIdentifierExcludeUnsafe);
+
+// limit function calls to specific utility functions that we provide
+
+function preprocessQuantifier(type, args) {
+    if(args.length > 2) {
+        throw new Error(`At most two arguments expected for "${type}" quantifier`);
+    }
+    let bindingVar, arrayExpr, predicateExpr;
+    if(args.length === 1) {
+        // treat "all(xs)" as equivalent to all(x in xs, x), but use a unique Symbol
+        // as the binding variable so it can't clash with any real variable names.
+        bindingVar = Symbol('x')
+        arrayExpr = args[0]
+        predicateExpr = {
+            type: 'Identifier',
+            name: bindingVar,
+        }
+    } else {
+        const binding = args[0]
+        if(binding.type !== 'BinaryExpression' || binding.operator !== 'in' || binding.left.type !== 'Identifier') {
+            throw new Error(`"${type}" quantifier binding must be of the form "identifier in expression"`);
+        }
+        bindingVar = binding.left.name
+        arrayExpr = binding.right
+        predicateExpr = args[1]
+    }
+    return [bindingVar, arrayExpr, predicateExpr]
+}
+
+/**
+ * Universal quantifier:
+ *
+ * all(x in expr, predicate)
+ *
+ * expr should evaluate to an array, we then evaluate predicate for each item in
+ * the array in turn, stopping if one of them returns a falsy value.
+ * @param exprEval ExpressionEval instance
+ * @param args array of nodes representing the arguments - there should be either
+ * one argument (evaluating to a list) or two arguments the first of which is
+ * "varName in expr" and the second an expression that can refer to the varName.
+ */
+function evalAllQuantifier(exprEval, args) {
+    let [bindingVar, arrayExpr, predicateExpr] = preprocessQuantifier("all", args)
+
+    const newContext = { ...exprEval.context }
+    return exprEval.eval(arrayExpr, (arr) => {
+        if(arr.length === 0) {
+            // trivially true if no items in the array
+            return true;
+        }
+        if (exprEval.isAsync) {
+            const evalOnce = (item, i) => {
+                newContext[bindingVar] = item
+                return ExpressionEval.evalAsync(predicateExpr, newContext).then((result) => {
+                    if(result) {
+                        i++;
+                        if (i >= arr.length) {
+                            return true
+                        } else {
+                            return evalOnce(arr[i], i)
+                        }
+                    } else {
+                        return false;
+                    }
+                })
+            }
+            return evalOnce(arr[0], 0)
+        } else {
+            return arr.every((item) => {
+                newContext[bindingVar] = item;
+                return ExpressionEval.eval(predicateExpr, newContext)
+            })
+        }
+    })
+}
+
+/**
+ * Existential quantifier:
+ *
+ * any(x in expr, predicate)
+ *
+ * expr should evaluate to an array, we then evaluate predicate for each item in
+ * the array in turn, stopping if one of them returns a truthy value.
+ * @param exprEval ExpressionEval instance
+ * @param args array of nodes representing the arguments - there should be either
+ * one argument (evaluating to a list) or two arguments the first of which is
+ * "varName in expr" and the second an expression that can refer to the varName.
+ */
+function evalAnyQuantifier(exprEval, args) {
+    let [bindingVar, arrayExpr, predicateExpr] = preprocessQuantifier("any", args)
+
+    const newContext = { ...exprEval.context }
+    return exprEval.eval(arrayExpr, (arr) => {
+        if (arr.length === 0) {
+            // trivially false if no items in the array
+            return false;
+        }
+        if (exprEval.isAsync) {
+            const evalOnce = (item, i) => {
+                newContext[bindingVar] = item
+                return ExpressionEval.evalAsync(predicateExpr, newContext).then((result) => {
+                    if (result) {
+                        return true;
+                    } else {
+                        i++;
+                        if (i >= arr.length) {
+                            return false
+                        } else {
+                            return evalOnce(arr[i], i)
+                        }
+                    }
+                })
+            }
+            return evalOnce(arr[0], 0)
+        } else {
+            return arr.some((item) => {
+                newContext[bindingVar] = item;
+                return ExpressionEval.eval(predicateExpr, newContext)
+            })
+        }
+    })
+}
+
+// Evaluator function - "this" within here refers to the ExpressionEval instance
+function evalFunctionCall(node) {
+    if(node.callee.type !== "Identifier") {
+        throw new Error("Illegal function call");
+    }
+    switch(node.callee.name) {
+        case "all":
+            return evalAllQuantifier(this, node.arguments)
+        case "any":
+            return evalAnyQuantifier(this, node.arguments)
+        default:
+            throw new Error(`Unsupported function "${node.callee.name}"`)
+    }
+}
+ExpressionEval.addEvaluator("CallExpression", evalFunctionCall);
+
+export { compile } from "jse-eval"

--- a/frontend/tests/component/AnnotationRenderer.cy.js
+++ b/frontend/tests/component/AnnotationRenderer.cy.js
@@ -510,7 +510,7 @@ describe("AnnotationRenderer", () => {
             })
         })
 
-        it('Test array condition', () => {
+        it('Test quantifier and regex', () => {
             cy.mount(AnnotationRenderer, {
                 propsData: {
                     config: [
@@ -526,7 +526,7 @@ describe("AnnotationRenderer", () => {
                         },
                         {
                             name: "has_a",
-                            if: "annotation.fruits.some((val) => val.includes('a'))",
+                            if: "any(val in annotation.fruits, val =~ /a/)",
                             type: "html",
                             text: "You like fruit with an 'a' in its name"
                         }
@@ -544,57 +544,6 @@ describe("AnnotationRenderer", () => {
             // check apple as well, label should now appear
             cy.get("input[name='fruits'][value='apple']").check({force: true})
             cy.contains('in its name').should('exist')
-        })
-
-        it('Test global objects', () => {
-            cy.mount(AnnotationRenderer, {
-                propsData: {
-                    config: [
-                        {
-                            name: "number1",
-                            type: "radio",
-                            title: "Pick a number",
-                            options: [
-                                {"value": "1", "label": "One"},
-                                {"value": "2", "label": "Two"},
-                                {"value": "3", "label": "Three"}
-                            ]
-                        },
-                        {
-                            name: "number2",
-                            type: "radio",
-                            title: "Pick another number",
-                            options: [
-                                {"value": "1", "label": "One"},
-                                {"value": "2", "label": "Two"},
-                                {"value": "3", "label": "Three"}
-                            ]
-                        },
-                        {
-                            name: "more_than_two",
-                            if: "Math.max(annotation.number1, annotation.number2) > 2",
-                            type: "html",
-                            text: "The highest number you picked was greater than 2"
-                        }
-                    ],
-                }
-            })
-
-            // html label should not be visible
-            cy.contains('highest number').should('not.exist')
-
-            // select 1 and 2
-            cy.get("input[name='number1'][value='1']").check({force: true})
-            cy.get("input[name='number2'][value='2']").check({force: true})
-
-            // html label should still not be visible
-            cy.contains('highest number').should('not.exist')
-
-            // select a 3
-            cy.get("input[name='number1'][value='3']").check({force: true})
-
-            // html label should appear
-            cy.contains('highest number').should('exist')
         })
     })
 })

--- a/frontend/tests/component/AnnotationRenderer.cy.js
+++ b/frontend/tests/component/AnnotationRenderer.cy.js
@@ -101,148 +101,150 @@ describe("AnnotationRenderer", () => {
 
     })
 
-    it('Test checkbox', () => {
+    describe('Test checkboxes', () => {
+        it('simple checkboxes', () => {
 
-        const annotationComps = [
-            {
-                name: "text",
-                type: "checkbox",
-                options: {
-                    "val1": "Val 1",
-                    "val2": "Val 2",
-                    "val3": "Val 3",
-                    "val4": "Val 4",
-                }
+            const annotationComps = [
+                {
+                    name: "text",
+                    type: "checkbox",
+                    options: {
+                        "val1": "Val 1",
+                        "val2": "Val 2",
+                        "val3": "Val 3",
+                        "val4": "Val 4",
+                    }
 
-            }]
+                }]
 
-        cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
+            cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
 
-        // Empty - Fail
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("be.visible")
+            // Empty - Fail
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("be.visible")
 
-        // Single selection - Pass
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
+            // Single selection - Pass
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
 
-        // Two selection - Pass
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.get("[name='text'][value='val2']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
+            // Two selection - Pass
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.get("[name='text'][value='val2']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
+
+        })
+
+        it('not optional', () => {
+
+            const annotationComps = [
+                {
+                    name: "text",
+                    type: "checkbox",
+                    optional: false,
+                    options: {
+                        "val1": "Val 1",
+                        "val2": "Val 2",
+                        "val3": "Val 3",
+                        "val4": "Val 4",
+                    }
+
+                }]
+
+            cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
+
+            // Empty - Fail
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("be.visible")
+
+            // Single selection - Pass
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
+
+            // Two selection - Pass
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.get("[name='text'][value='val2']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
+
+
+        })
+
+        it('optional', () => {
+
+            const annotationComps = [
+                {
+                    name: "text",
+                    type: "checkbox",
+                    optional: true,
+                    options: {
+                        "val1": "Val 1",
+                        "val2": "Val 2",
+                        "val3": "Val 3",
+                        "val4": "Val 4",
+                    }
+
+                }]
+
+            cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
+
+
+            // Empty - Pass
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
+
+            // Single selection - Pass
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
+
+            // Two selection - Pass
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.get("[name='text'][value='val2']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
+
+
+        })
+
+        it('minSelected=2', () => {
+            const annotationComps = [
+                {
+                    name: "text",
+                    type: "checkbox",
+                    minSelected: 2,
+                    options: {
+                        "val1": "Val 1",
+                        "val2": "Val 2",
+                        "val3": "Val 3",
+                        "val4": "Val 4",
+                    }
+
+                }]
+
+            cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
+
+            // Empty - Fail
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("be.visible")
+
+            // Single selection - Fail
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("be.visible")
+
+            // Two selection - Pass
+            cy.get("[name='text'][value='val1']").check({force: true})
+            cy.get("[name='text'][value='val2']").check({force: true})
+            cy.contains(submitButtonStr).click()
+            cy.contains(annotationErrorStr).should("not.be.visible")
+
+
+        })
 
     })
-
-    it('Test checkbox not optional', () => {
-
-        const annotationComps = [
-            {
-                name: "text",
-                type: "checkbox",
-                optional: false,
-                options: {
-                    "val1": "Val 1",
-                    "val2": "Val 2",
-                    "val3": "Val 3",
-                    "val4": "Val 4",
-                }
-
-            }]
-
-        cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
-
-        // Empty - Fail
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("be.visible")
-
-        // Single selection - Pass
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
-
-        // Two selection - Pass
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.get("[name='text'][value='val2']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
-
-
-    })
-
-    it('Test checkbox optional', () => {
-
-        const annotationComps = [
-            {
-                name: "text",
-                type: "checkbox",
-                optional: true,
-                options: {
-                    "val1": "Val 1",
-                    "val2": "Val 2",
-                    "val3": "Val 3",
-                    "val4": "Val 4",
-                }
-
-            }]
-
-        cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
-
-
-        // Empty - Pass
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
-
-        // Single selection - Pass
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
-
-        // Two selection - Pass
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.get("[name='text'][value='val2']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
-
-
-    })
-
-    it('Test checkbox minSelected=2', () => {
-        const annotationComps = [
-            {
-                name: "text",
-                type: "checkbox",
-                minSelected: 2,
-                options: {
-                    "val1": "Val 1",
-                    "val2": "Val 2",
-                    "val3": "Val 3",
-                    "val4": "Val 4",
-                }
-
-            }]
-
-        cy.mount(AnnotationRenderer, {propsData: {config: annotationComps}})
-
-        // Empty - Fail
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("be.visible")
-
-        // Single selection - Fail
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("be.visible")
-
-        // Two selection - Pass
-        cy.get("[name='text'][value='val1']").check({force: true})
-        cy.get("[name='text'][value='val2']").check({force: true})
-        cy.contains(submitButtonStr).click()
-        cy.contains(annotationErrorStr).should("not.be.visible")
-
-
-    })
-
 
     it('Test dynamic options fromDocument', () => {
         cy.fixture("test_from_document_fixture").then(fixture => {
@@ -416,5 +418,183 @@ describe("AnnotationRenderer", () => {
         })
 
 
+    })
+
+    describe("Conditional widgets", () => {
+        it('Test condition based only on annotation', () => {
+            cy.fixture("project_config_conditional").then((conf) => {
+                cy.mount(AnnotationRenderer, {
+                    propsData: {
+                        config: conf,
+                        document: {
+                            "text": "I couldn't care either way about the thing."
+                        },
+                    }
+                })
+
+                cy.get("input[name='sentiment']").first().check({force: true})
+
+                // initially the confidence reason field should not be shown
+                cy.get("input[name='confidence_reason']").should("not.exist")
+
+                cy.get("input[name='confidence'][value='3']").check({force: true})
+                // now confidence is set to 3, reason field should appear
+                cy.get("input[name='confidence_reason']").should("exist")
+
+                // Submit should fail as confidence_reason not filled in
+                cy.contains(submitButtonStr).click()
+                cy.get("div.invalid-feedback").should("be.visible")
+
+                cy.get("input[name='confidence'][value='5']").check({force: true})
+                // now confidence is set to 5, reason field should vanish
+                cy.get("input[name='confidence_reason']").should("not.exist")
+
+                // Submit should now succeed even though reason not filled in, since only
+                // visible fields are validated
+                cy.contains(submitButtonStr).click()
+                // not.be.visible means at least one matching item is not visible, we instead
+                // need to check that *all* the items are not visible, so filter for the visible
+                // ones and assert that there are none of them
+                cy.get("div.invalid-feedback:visible").should("not.exist")
+            })
+        })
+
+        it('Test document condition', () => {
+            cy.fixture("project_config_conditional").then((conf) => {
+                cy.mount(AnnotationRenderer, {
+                    propsData: {
+                        config: conf,
+                        document: {
+                            "text": "I <i>love</i> this thing!",
+                            "preanno": {
+                                "sentiment": "positive"
+                            }
+                        },
+                        doc_preannotation_field: "preanno",
+                    }
+                })
+
+                // initially the "why do you disagree" field should not be shown
+                cy.get("input[name='reason']").should("not.exist")
+                // and positive sentiment should be selected
+                cy.get("input[name='sentiment'][value='positive']").should("be.checked")
+
+                // select a different value
+                cy.get("input[name='sentiment'][value='neutral']").check({force: true})
+                // "why do you disagree" field should appear
+                cy.get("input[name='reason']").should("exist")
+            })
+        })
+
+        it('Test condition with error', () => {
+            cy.fixture("project_config_conditional").then((conf) => {
+                cy.mount(AnnotationRenderer, {
+                    propsData: {
+                        config: conf,
+                        document: {
+                            "text": "I <i>loathe</i> this thing!",
+                        },
+                        doc_preannotation_field: "preanno",
+                    }
+                })
+
+                // initially the "why do you disagree" field should not be shown
+                cy.get("input[name='reason']").should("not.exist")
+                // and no sentiment should be selected (as the if expression throws an error with preanno missing)
+                cy.get("input[name='sentiment']").should("not.be.checked")
+
+                // select a value
+                cy.get("input[name='sentiment'][value='neutral']").check({force: true})
+                // "why do you disagree" field should still be absent, as the if expression still throws an error
+                cy.get("input[name='reason']").should("not.exist")
+            })
+        })
+
+        it('Test array condition', () => {
+            cy.mount(AnnotationRenderer, {
+                propsData: {
+                    config: [
+                        {
+                            name: "fruits",
+                            type: "checkbox",
+                            title: "Which fruits do you like?",
+                            options: [
+                                {"value": "apple", "label": "Apple"},
+                                {"value": "orange", "label": "Orange"},
+                                {"value": "kiwi", "label": "Kiwi fruit"}
+                            ]
+                        },
+                        {
+                            name: "has_a",
+                            if: "annotation.fruits.some((val) => val.includes('a'))",
+                            type: "html",
+                            text: "You like fruit with an 'a' in its name"
+                        }
+                    ],
+                }
+            })
+
+            // html label should not be visible
+            cy.contains('in its name').should('not.exist')
+
+            // check kiwi, label should still not be visible
+            cy.get("input[name='fruits'][value='kiwi']").check({force: true})
+            cy.contains('in its name').should('not.exist')
+
+            // check apple as well, label should now appear
+            cy.get("input[name='fruits'][value='apple']").check({force: true})
+            cy.contains('in its name').should('exist')
+        })
+
+        it('Test global objects', () => {
+            cy.mount(AnnotationRenderer, {
+                propsData: {
+                    config: [
+                        {
+                            name: "number1",
+                            type: "radio",
+                            title: "Pick a number",
+                            options: [
+                                {"value": "1", "label": "One"},
+                                {"value": "2", "label": "Two"},
+                                {"value": "3", "label": "Three"}
+                            ]
+                        },
+                        {
+                            name: "number2",
+                            type: "radio",
+                            title: "Pick another number",
+                            options: [
+                                {"value": "1", "label": "One"},
+                                {"value": "2", "label": "Two"},
+                                {"value": "3", "label": "Three"}
+                            ]
+                        },
+                        {
+                            name: "more_than_two",
+                            if: "Math.max(annotation.number1, annotation.number2) > 2",
+                            type: "html",
+                            text: "The highest number you picked was greater than 2"
+                        }
+                    ],
+                }
+            })
+
+            // html label should not be visible
+            cy.contains('highest number').should('not.exist')
+
+            // select 1 and 2
+            cy.get("input[name='number1'][value='1']").check({force: true})
+            cy.get("input[name='number2'][value='2']").check({force: true})
+
+            // html label should still not be visible
+            cy.contains('highest number').should('not.exist')
+
+            // select a 3
+            cy.get("input[name='number1'][value='3']").check({force: true})
+
+            // html label should appear
+            cy.contains('highest number').should('exist')
+        })
     })
 })

--- a/frontend/tests/unit/utils/expressions.spec.js
+++ b/frontend/tests/unit/utils/expressions.spec.js
@@ -49,19 +49,41 @@ describe("Expression parsing & evaluation", () => {
         })).toBeFalsy()
     })
 
-    it("Test existential quantifier with predicate", () => {
-        const allFn = compile("any(v in annotation.values, v < 3)")
+    it("Test universal quantifier over object", () => {
+        const allFn = compile("all(prop in document.labels, prop.value > 0.5)")
         expect(allFn({
+            document: {
+                labels: {
+                    "a": 0.3,
+                    "b": 0.8,
+                    "c": 0.95
+                }
+            }
+        })).toBeFalsy()
+        expect(allFn({
+            document: {
+                labels: {
+                    "a": 0.6,
+                    "b": 0.8,
+                    "c": 0.95
+                }
+            }
+        })).toBeTruthy()
+    })
+
+    it("Test existential quantifier with predicate", () => {
+        const anyFn = compile("any(v in annotation.values, v < 3)")
+        expect(anyFn({
             annotation: {
                 values: []
             }
         })).toBeFalsy()
-        expect(allFn({
+        expect(anyFn({
             annotation: {
                 values: ["1", "4"]
             }
         })).toBeTruthy()
-        expect(allFn({
+        expect(anyFn({
             annotation: {
                 values: ["3", "4"]
             }
@@ -78,6 +100,28 @@ describe("Expression parsing & evaluation", () => {
         expect(anyFnNoPredicate({
             annotation: {
                 values: [null, "", 0]
+            }
+        })).toBeFalsy()
+    })
+
+    it("Test existential quantifier over object", () => {
+        const anyFn = compile("any(prop in document.labels, prop.value < 0.5)")
+        expect(anyFn({
+            document: {
+                labels: {
+                    "a": 0.3,
+                    "b": 0.8,
+                    "c": 0.95
+                }
+            }
+        })).toBeTruthy()
+        expect(anyFn({
+            document: {
+                labels: {
+                    "a": 0.6,
+                    "b": 0.8,
+                    "c": 0.95
+                }
             }
         })).toBeFalsy()
     })

--- a/frontend/tests/unit/utils/expressions.spec.js
+++ b/frontend/tests/unit/utils/expressions.spec.js
@@ -1,0 +1,143 @@
+import { describe, it ,expect, vi } from 'vitest'
+import { compile } from '@/utils/expressions'
+
+describe("Expression parsing & evaluation", () => {
+    it("Test simple expression", () => {
+        const fn = compile('annotation.confidence >= 4');
+        expect(fn({
+            annotation: {
+                confidence: "5"
+            }
+        })).toBeTruthy();
+        expect(fn({
+            annotation: {
+                confidence: "3"
+            }
+        })).toBeFalsy();
+    })
+
+    it("Test universal quantifier with predicate", () => {
+        const allFn = compile("all(v in annotation.values, v < 3)")
+        expect(allFn({
+            annotation: {
+                values: []
+            }
+        })).toBeTruthy()
+        expect(allFn({
+            annotation: {
+                values: ["1", "2"]
+            }
+        })).toBeTruthy()
+        expect(allFn({
+            annotation: {
+                values: ["1", "2", "3"]
+            }
+        })).toBeFalsy()
+    })
+
+    it("Test universal quantifier without predicate", () => {
+        const allFnNoPredicate = compile("all(annotation.values)")
+        expect(allFnNoPredicate({
+            annotation: {
+                values: ["1", "2", "3"]
+            }
+        })).toBeTruthy()
+        expect(allFnNoPredicate({
+            annotation: {
+                values: ["1", "", "3"]
+            }
+        })).toBeFalsy()
+    })
+
+    it("Test existential quantifier with predicate", () => {
+        const allFn = compile("any(v in annotation.values, v < 3)")
+        expect(allFn({
+            annotation: {
+                values: []
+            }
+        })).toBeFalsy()
+        expect(allFn({
+            annotation: {
+                values: ["1", "4"]
+            }
+        })).toBeTruthy()
+        expect(allFn({
+            annotation: {
+                values: ["3", "4"]
+            }
+        })).toBeFalsy()
+    })
+
+    it("Test existential quantifier without predicate", () => {
+        const anyFnNoPredicate = compile("any(annotation.values)")
+        expect(anyFnNoPredicate({
+            annotation: {
+                values: ["1", 0, ""]
+            }
+        })).toBeTruthy()
+        expect(anyFnNoPredicate({
+            annotation: {
+                values: [null, "", 0]
+            }
+        })).toBeFalsy()
+    })
+
+    it("Test compile error (invalid syntax)", () => {
+        expect(() => compile("annotation.foo <")).toThrowError()
+    })
+
+    it("Test compile error (unsupported expression types)", () => {
+        expect(() => compile("annotation.foo = 4")).toThrowError()
+        expect(() => compile("annotation.bar += 3")).toThrowError()
+    })
+
+    it("Test access to 'prototype' is forbidden at runtime", () => {
+        const fn = compile("annotation.prototype.foo")
+        expect(() => fn({annotation: {}})).toThrowError(/Access to member .* disallowed/);
+    })
+
+    it("Test access to '__ob__' as a member is forbidden at runtime", () => {
+        const fn = compile("annotation['__ob__'].dep.subs[0]")
+        expect(() => fn({annotation: {}})).toThrowError(/Access to member .* disallowed/);
+    })
+
+    it("Test access to '__ob__' as a top-level identifier is forbidden at runtime", () => {
+        const fn = compile("__ob__.dep.subs[0]")
+        expect(() => fn({__ob__: {}})).toThrowError(/Access to member .* disallowed/);
+    })
+
+    it("Test other function calls are forbidden", () => {
+        const fnCallMethod = compile("example.method()")
+        expect(() => fnCallMethod({
+            example: {
+                method() {return true}
+            }
+        })).toThrowError(/function/);
+
+        const fnCallTopLevel = compile("someFunc()")
+        expect(() => fnCallTopLevel({
+            someFunc() { return true }
+        })).toThrowError(/function/);
+    })
+
+    it("Test Object.assign is unavailable at runtime", () => {
+        const fn = compile("Object.assign(annotation, {foo: 'bar'})")
+        const ctx = {annotation: {}};
+        expect(() => fn(ctx)).toThrowError() // illegal function call
+        expect(ctx.annotation.foo).toBeUndefined() // ctx is unchanged
+    })
+
+    it("Test regex operator", () => {
+        const fn = compile("annotation.val =~ /^b/")
+        expect(fn({annotation: {val: "foo"}})).toBeFalsy()
+        expect(fn({annotation: {val: "bar"}})).toBeTruthy()
+    })
+
+    it("Test 'in' operator", () => {
+        const fn = compile("'hello' in things")
+        expect(fn({things: ['hello', 'world']})).toBeTruthy()
+        expect(fn({things: ['goodbye', 'world']})).toBeFalsy()
+        expect(fn({things: {'hello': 'world'}})).toBeTruthy()
+        expect(fn({things: {'world': 'hello'}})).toBeFalsy()
+    })
+})


### PR DESCRIPTION
This is a first pass at implementing the "conditional" part of #164 - I've added an `if` option to the project config language, whose value is an expression that is evaluated against the current document data and the current state of the annotation data for that document, allowing widgets to decide whether they should be displayed based on the values set in other widgets.  For example:

```json
[
  {
    "name": "Document",
    "text": "{{{text}}}",
    "type": "html"
  },
  {
    "name": "sentiment",
    "type": "radio",
    "title": "Sentiment",
    "options": [
      "negative",
      "neutral",
      "positive"
    ]
  },
  {
    "type": "radio",
    "title": "Confidence",
    "name": "confidence",
    "options": [
      {"value":"1", "label": "1 (Not at all confident)"},
      "2","3","4",
      {"value": "5", "label": "5 (dead certain)"}
    ]
  },
  {
    "if": "annotation.confidence < 4",
    "name": "reason",
    "type": "text",
    "regex": "...",
    "title": "What makes you unsure?"
  }
]
```

In this example the "reason" field only appears if you select confidence level 1, 2 or 3, and the way I've done it the validation only checks visible components, so in this case the `regex` check on `reason` (requiring at least three characters) doesn't block submission when `confidence` is set to 4 or 5.

~~I've used the [jexl](https://www.npmjs.com/package/jexl) expression library but the last release of that looks like it was several years back, and there's at least one open issue on there that says it's vulnerable to prototype pollution attacks, so it may be worth looking for a different expression parser,~~ Edit: I've switched to [jse-eval](https://www.npmjs.com/package/jse-eval), which explicitly denies any access to `__proto__` and related properties.

I thought I'd submit this now so you can see what you think of the idea in principle.  Tasks still to do include:

- [x] Tests
- [x] Documentation