### PR TITLE
Correct DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,7 +26,7 @@ identifiers:
 - description: The collection of archived snapshots of all versions of GATE Teamware
     2
   type: doi
-  value: 10.5281/zenodo.7821718
+  value: 10.5281/zenodo.7899193
 keywords:
 - NLP
 - machine learning

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![](/frontend/public/static/img/gate-teamware-logo.svg "GATE Teamware")
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7821718.svg)](https://doi.org/10.5281/zenodo.7821718)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7899193.svg)](https://doi.org/10.5281/zenodo.7899193)
 
 A web application for collaborative document annotation. 
 
 Full documentation can be [found here][docs].
 
-GATE teamware provides a flexible web app platform for managing classification of documents by human annotators.
+GATE Teamware provides a flexible web app platform for managing classification of documents by human annotators.
 
 ## Key Features
 * Configure annotation options using a highly flexible JSON config.
@@ -63,7 +63,7 @@ Teamware is developed by the [GATE](https://gate.ac.uk) team, an academic resear
 ## Citation
 For published work that has used Teamware, please cite this repository. One way is to include a citation such as:
 
-> Karmakharm, T., Wilby, D., Roberts, I., & Bontcheva, K. (2022). GATE Teamware (Version 0.1.4) [Computer software]. https://github.com/GateNLP/gate-teamware
+> Karmakharm, T., Wilby, D., Roberts, I., & Bontcheva, K. (2022). GATE Teamware (Version 2.1.0) [Computer software]. https://github.com/GateNLP/gate-teamware
 
 Please use the `Cite this repository` button at the top of the [project's GitHub repository](https://github.com/GATENLP/gate-teamware) to get an up to date citation.
 

--- a/version.py
+++ b/version.py
@@ -8,6 +8,7 @@ DOCS_PACKAGE_JSON_FILE_PATH = "docs/package.json"
 CITATION_FILE_PATH = "CITATION.cff"
 MASTER_VERSION_FILE = "VERSION"
 README_FILE_PATH = "README.md"
+README_VERSION_REGEX = r"\(Version ([^)]*)\)"
 
 def check():
     """
@@ -49,7 +50,7 @@ def get_readme_version(file_path: str) -> str:
     with open(file_path, 'r') as f:
         readme_text = f.read()
     
-    match = re.search(r'\(Version (.*)\)', readme_text)
+    match = re.search(README_VERSION_REGEX, readme_text)
 
     if match is None:
         print(f"No version found in {README_FILE_PATH}.")
@@ -99,7 +100,7 @@ def update_readme_version(file_path:str, version_no:str):
         readme_text = f.read()
     
     readme_text = re.sub(
-           r'\(Version (.*)\)', 
+           README_VERSION_REGEX, 
            f'(Version {version_no})', 
            readme_text
        )


### PR DESCRIPTION
For some reason the last release created a new Zenodo record rather than adding the new version to the existing record. This replacement DOI points to the most recent version on the new record, which is linked to the repo via my Zenodo account.

Could alternatively merge to master, rather than dev.