### PR TITLE
Add transition effect when document changes

### DIFF
--- a/frontend/src/views/Annotate.vue
+++ b/frontend/src/views/Annotate.vue
@@ -241,7 +241,6 @@ export default {
     // Go to previous task in the history
     toPreviousTask() {
       if (this.hasPreviousTask()) {
-        this.triggerAnnotationRendererTransition()
         this.currentTaskIndex += 1
         this.getCurrentTask()
       }
@@ -249,14 +248,12 @@ export default {
     // Goes to next task in history
     toNextTask() {
       if (this.hasNextTask()) {
-        this.triggerAnnotationRendererTransition()
         this.currentTaskIndex -= 1
         this.getCurrentTask()
       }
     },
     // Goes to the latest task
     toLatestTask() {
-      this.triggerAnnotationRendererTransition()
       this.currentTaskIndex = 0
       this.getCurrentTask()
     },
@@ -287,13 +284,15 @@ export default {
             this.$refs.annotationRenderer.setAnnotationData(this.currentAnnotationTask.annotation_data)
         }
 
+        this.triggerAnnotationRendererTransition()
+
       } catch (e) {
         toastError("Could not get annotation task", e, this)
         console.log(e)
       }
     },
     async submitHandler(value, time) {
-      this.triggerAnnotationRendererTransition()
+
 
       if (this.isLatestTask()) {
         // Complete a current task
@@ -325,7 +324,6 @@ export default {
     },
 
     async rejectHandler() {
-      this.triggerAnnotationRendererTransition()
 
       try {
         await this.rejectUserAnnotationTask(this.annotationTask.annotation_id)

--- a/frontend/src/views/Annotate.vue
+++ b/frontend/src/views/Annotate.vue
@@ -103,6 +103,7 @@
                               :doc_preannotation_field="currentAnnotationTask.document_pre_annotation_field"
                               :allow_document_reject="isLatestTask() && currentAnnotationTask.allow_document_reject"
                               :clear_after_submit="clearFormAfterSubmit"
+                              :class="{documentChanged : annotationRendererTransitionEnabled}"
                               @submit="submitHandler"
                               @reject="rejectHandler"
           ></AnnotationRenderer>
@@ -188,6 +189,7 @@ export default {
       showLeaveProjectModal: false,
       showStageIntroCard: false,
       showThankyouCard: false,
+      annotationRendererTransitionEnabled: false,
     }
   },
 
@@ -195,6 +197,12 @@ export default {
     ...mapActions(["getUserAnnotationTask", "getUserAnnotationTaskWithID",
       "completeUserAnnotationTask", "rejectUserAnnotationTask", "annotatorLeaveProject",
       "changeAnnotation"]),
+    triggerAnnotationRendererTransition(){
+      this.annotationRendererTransitionEnabled = true
+      setTimeout(()=>{
+        this.annotationRendererTransitionEnabled = false
+      }, 500)
+    },
     getAnnotationContainerBgClass() {
       return {
         "mt-4": true,
@@ -233,6 +241,7 @@ export default {
     // Go to previous task in the history
     toPreviousTask() {
       if (this.hasPreviousTask()) {
+        this.triggerAnnotationRendererTransition()
         this.currentTaskIndex += 1
         this.getCurrentTask()
       }
@@ -240,12 +249,14 @@ export default {
     // Goes to next task in history
     toNextTask() {
       if (this.hasNextTask()) {
+        this.triggerAnnotationRendererTransition()
         this.currentTaskIndex -= 1
         this.getCurrentTask()
       }
     },
     // Goes to the latest task
     toLatestTask() {
+      this.triggerAnnotationRendererTransition()
       this.currentTaskIndex = 0
       this.getCurrentTask()
     },
@@ -282,6 +293,7 @@ export default {
       }
     },
     async submitHandler(value, time) {
+      this.triggerAnnotationRendererTransition()
 
       if (this.isLatestTask()) {
         // Complete a current task
@@ -313,6 +325,8 @@ export default {
     },
 
     async rejectHandler() {
+      this.triggerAnnotationRendererTransition()
+
       try {
         await this.rejectUserAnnotationTask(this.annotationTask.annotation_id)
       } catch (e) {
@@ -417,6 +431,19 @@ export default {
   background-image: none;
   background: white;
 
+}
+
+.documentChanged {
+  animation: fadein 0.5s;
+}
+
+@keyframes fadein {
+  from{
+    opacity: 0;
+  }
+  to{
+    opacity: 1.0;
+  }
 }
 
 </style>


### PR DESCRIPTION
Resolves #324 

* Added a 0.5s fadein transition when:
  * Annotation is submitted (and validated)
  * Annotation is rejected
  * Skipping to previous, next and current documents

[Screencast 2023-05-12 15:36:52.webm](https://github.com/GateNLP/gate-teamware/assets/11231792/15f1658f-3b48-4f4e-8b11-6714dc322298)
