### PR TITLE
Better frontend error page when backend is down

### DIFF
--- a/cypress/e2e/connection-error.spec.js
+++ b/cypress/e2e/connection-error.spec.js
@@ -1,0 +1,31 @@
+
+
+describe("Test connection errors", () =>{
+
+    it("Test initialise with 404 response", () => {
+
+        cy.intercept("POST", "/rpc/",
+          {
+            statusCode: 404,
+              body: {
+
+              }
+          }
+        ).as('rpcCalls') // and assign an alias
+        cy.visit("/")
+        cy.contains("TEAMWARE").should("be.visible")
+    })
+
+    it("Test initialise with blank response", () =>{
+        cy.intercept(
+          {
+            method: 'POST', // Route all GET requests
+            url: '/rpc/', // that have a URL that matches '/users/*'
+          },
+          [] // and force the response to be: []
+        ).as('rpcCalls') // and assign an alias
+        cy.visit("/")
+        cy.contains("TEAMWARE").should("be.visible")
+    })
+
+})

--- a/frontend/src/jrpc/index.js
+++ b/frontend/src/jrpc/index.js
@@ -73,8 +73,9 @@ class JRPCClient{
                 // Not a fully formed json-rpc response, may be a problem with the endpoint
                 // or connection to the server
                 // TODO: Do we care about specific connection errors?
-                const err = new Error("Unknown error")
+                const err = new Error("There appears to be a problem with the connection")
                 err.code = JRPCClient.INTERNAL_ERROR
+                err.response = e.response
                 throw err
             }
         }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -68,7 +68,7 @@ export default new Vuex.Store({
 
             }catch(e){
                 console.log(e)
-                throw e
+                // Error is not thrown as this function is called before the UI is loaded
             }
         },
         async login({dispatch, commit}, params) {


### PR DESCRIPTION
Resolves #344 

* Stop throwing error on the rpc initialise call (frontend) as the function is actually called outside the scope of the UI app 
* Added tests to ensure that frontpage loads even after initialise call fails
* Changed "Unknown error" message to "There appears to be a problem with the connection", this error is thrown when we receive a non/malformed jsonrpc response and most likely to happen in cases where there's a connection error (or trying to access a non-existent endpoint)