### PR TITLE
Fixes for various export related issues

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1019,8 +1019,9 @@ class Document(models.Model):
             annotation_sets = {}
             for annotation in annotations:
                 a_data = annotation.data
+                anonymized_name = f"{settings.ANONYMIZATION_PREFIX}{annotation.user.id}"
                 annotation_set = {
-                    "name": annotation.user.id if anonymize else annotation.user.username,
+                    "name": anonymized_name if anonymize else annotation.user.username,
                     "annotations": [
                         {
                             "type": "Document",
@@ -1035,7 +1036,7 @@ class Document(models.Model):
                     ],
                     "next_annid": 1,
                 }
-                annotation_sets[annotation.user.username] = annotation_set
+                annotation_sets[anonymized_name if anonymize else annotation.user.username] = annotation_set
             doc_dict["annotation_sets"] = annotation_sets
 
         # Add to the export the lists (possibly empty) of users who rejected,

--- a/backend/models.py
+++ b/backend/models.py
@@ -1008,7 +1008,7 @@ class Document(models.Model):
                 annotation_dict["duration_seconds"] = annotation.time_to_complete
 
                 if anonymize:
-                    annotation_sets[str(annotation.user.id)] = annotation_dict
+                    annotation_sets[f"{settings.ANONYMIZATION_PREFIX}{annotation.user.id}"] = annotation_dict
                 else:
                     annotation_sets[annotation.user.username] = annotation_dict
 
@@ -1048,7 +1048,7 @@ class Document(models.Model):
             ("aborted", Annotation.ABORTED),
         ]:
             teamware_status[key] = [
-                annotation.user.id if anonymize else annotation.user.username
+                f"{settings.ANONYMIZATION_PREFIX}{annotation.user.id}" if anonymize else annotation.user.username
                 for annotation in self.annotations.filter(status=status)
             ]
             if json_format == "csv":

--- a/backend/models.py
+++ b/backend/models.py
@@ -980,9 +980,12 @@ class Document(models.Model):
         if json_format == "raw" or json_format == "csv":
             doc_dict = self.data.copy()
         elif json_format == "gate":
+            # GATE json format are expected to have an existing "features" field
+            features_dict = self.data["features"] if "features" in self.data and isinstance(self.data["features"], dict) else {}
 
-            ignore_keys = {"text", self.project.document_id_field}
-            features_dict = {key: value for key, value in self.data.items() if key not in ignore_keys}
+            # Add any non-compliant top-level fields into the "features" field instead
+            ignore_keys = {"text", "features", self.project.document_id_field}
+            features_dict.update({key: value for key, value in self.data.items() if key not in ignore_keys})
 
             doc_dict = {
                 "text": self.data["text"],

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1098,8 +1098,9 @@ class TestAnnotationModel(ModelTestCase):
 class TestDocumentAnnotationModelExport(TestCase):
 
     def setUp(self):
+        self.unanonymized_prefix = "namedperson"
         self.test_user = get_user_model().objects.create(username="project_creator")
-        self.annotator_names = [f"anno{i}" for i in range(3)]
+        self.annotator_names = [f"{self.unanonymized_prefix}{i}" for i in range(3)]
         self.annotators = [get_user_model().objects.create(username=u) for u in self.annotator_names]
         self.annotator_ids = [a.id for a in self.annotators]
         self.project = Project.objects.create(owner=self.test_user)
@@ -1233,7 +1234,8 @@ class TestDocumentAnnotationModelExport(TestCase):
             doc_dict = document.get_doc_annotation_dict("raw", anonymize=True)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():
-                self.assertTrue(isinstance(aset_data.get("name", None), int))
+                self.assertFalse(aset_key.startswith(self.unanonymized_prefix))
+                self.assertFalse(aset_data.get("name", None).startswith(self.unanonymized_prefix))
 
             self.check_teamware_status(doc_dict, self.annotator_ids)
 
@@ -1243,7 +1245,8 @@ class TestDocumentAnnotationModelExport(TestCase):
             doc_dict = document.get_doc_annotation_dict("raw", anonymize=False)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():
-                self.assertTrue(isinstance(aset_data.get("name", None), str))
+                self.assertTrue(aset_key.startswith(self.unanonymized_prefix))
+                self.assertTrue(aset_data.get("name", None).startswith(self.unanonymized_prefix))
 
             # for non-anonymized export the rejected/aborted/timed_out status
             # uses names rather than ID numbers
@@ -1255,7 +1258,8 @@ class TestDocumentAnnotationModelExport(TestCase):
             doc_dict = document.get_doc_annotation_dict("gate", anonymize=True)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():
-                self.assertTrue(isinstance(aset_data.get("name", None), int))
+                self.assertFalse(aset_key.startswith(self.unanonymized_prefix))
+                self.assertFalse(aset_data.get("name", None).startswith(self.unanonymized_prefix))
 
             self.check_teamware_status(doc_dict["features"], self.annotator_ids)
 
@@ -1265,7 +1269,8 @@ class TestDocumentAnnotationModelExport(TestCase):
             doc_dict = document.get_doc_annotation_dict("gate", anonymize=False)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():
-                self.assertTrue(isinstance(aset_data.get("name", None), str))
+                self.assertTrue(aset_key.startswith(self.unanonymized_prefix))
+                self.assertTrue(aset_data.get("name", None).startswith(self.unanonymized_prefix))
 
             # for non-anonymized export the rejected/aborted/timed_out status
             # uses names rather than ID numbers

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1113,6 +1113,11 @@ class TestDocumentAnnotationModelExport(TestCase):
                     "feature1": "Testvalue 1",
                     "feature2": "Testvalue 1",
                     "feature3": "Testvalue 1",
+                    "features": {
+                        "gate_format_feature1": "Gate feature test value",
+                        "gate_format_feature2": "Gate feature test value",
+                        "gate_format_feature3": "Gate feature test value",
+                    }
 
                 }
             )
@@ -1148,6 +1153,8 @@ class TestDocumentAnnotationModelExport(TestCase):
     def test_export_raw(self):
 
         for document in self.project.documents.all():
+            # Fields should remain exactly the same as what's been uploaded
+            # aside from  annotation_sets
             doc_dict = document.get_doc_annotation_dict("raw")
             print(doc_dict)
             self.assertTrue("id" in doc_dict)
@@ -1155,6 +1162,11 @@ class TestDocumentAnnotationModelExport(TestCase):
             self.assertTrue("feature1" in doc_dict)
             self.assertTrue("feature2" in doc_dict)
             self.assertTrue("feature3" in doc_dict)
+            self.assertTrue("features" in doc_dict)
+            doc_features = doc_dict["features"]
+            self.assertTrue("gate_format_feature1" in doc_features)
+            self.assertTrue("gate_format_feature2" in doc_features)
+            self.assertTrue("gate_format_feature3" in doc_features)
 
             self.check_raw_gate_annotation_formatting(doc_dict)
             self.check_teamware_status(doc_dict, self.anon_annotator_names)
@@ -1162,6 +1174,8 @@ class TestDocumentAnnotationModelExport(TestCase):
     def test_export_gate(self):
 
         for document in self.project.documents.all():
+            # All top-level fields apart from name, text, features and annotation_sets should be
+            # nested inside the features field
             doc_dict = document.get_doc_annotation_dict("gate")
             print(doc_dict)
 
@@ -1172,6 +1186,10 @@ class TestDocumentAnnotationModelExport(TestCase):
             self.assertTrue("feature1" in doc_features)
             self.assertTrue("feature2" in doc_features)
             self.assertTrue("feature3" in doc_features)
+            self.assertFalse("features" in doc_features, "Double nesting of features field")
+            self.assertTrue("gate_format_feature1" in doc_features)
+            self.assertTrue("gate_format_feature2" in doc_features)
+            self.assertTrue("gate_format_feature3" in doc_features)
 
             self.check_raw_gate_annotation_formatting(doc_dict)
             self.check_teamware_status(doc_features, self.anon_annotator_names)

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1123,7 +1123,7 @@ class TestDocumentAnnotationModelExport(TestCase):
                         "existing_annotator1": {
                             "sentiment": "positive"
                         },
-                        f"2": {
+                        f"{settings.ANONYMIZATION_PREFIX}{self.annotators[0].pk}": {
                             "sentiment": "positive"
                         }
 
@@ -1144,8 +1144,8 @@ class TestDocumentAnnotationModelExport(TestCase):
                             ],
                             "next_annid": 1
                         },
-                        f"{settings.ANONYMIZATION_PREFIX}2": {
-                            "name": f"{settings.ANONYMIZATION_PREFIX}1",
+                        f"{settings.ANONYMIZATION_PREFIX}{self.annotators[0].pk}": {
+                            "name": f"{settings.ANONYMIZATION_PREFIX}{self.annotators[0].pk}",
                             "annotations": [
                                 {
                                     "type": "Document",
@@ -1254,9 +1254,9 @@ class TestDocumentAnnotationModelExport(TestCase):
             self.assertEqual(doc_dict["offset_type"], "p", "offset_type should default to p")
 
 
-    def check_raw_gate_annotation_formatting(self, doc_dict):
+    def check_raw_gate_annotation_formatting(self, doc_dict: dict):
         self.assertTrue("annotation_sets" in doc_dict)
-        self.assertEqual(len(doc_dict["annotation_sets"]), 4)
+        self.assertEqual(len(doc_dict["annotation_sets"]), 4, doc_dict)
 
         # Test annotation formatting
         for aset_key, aset_data in doc_dict["annotation_sets"].items():
@@ -1304,7 +1304,7 @@ class TestDocumentAnnotationModelExport(TestCase):
             self.assertTrue("feature2" in doc_dict)
             self.assertTrue("feature3" in doc_dict)
             self.assertTrue("annotations" in doc_dict)
-            self.assertEqual(len(doc_dict["annotations"]), 4)
+            self.assertEqual(len(doc_dict["annotations"]), 4, doc_dict)
             anno_set_dict = doc_dict["annotations"]
             for set_key in anno_set_dict:
                 if set_key != "existing_annotator1":
@@ -1318,6 +1318,10 @@ class TestDocumentAnnotationModelExport(TestCase):
     def test_export_raw_anonymized(self):
 
         for document in self.project.documents.all():
+            # Mask any existing annotations that came with the document upload
+            document.data.pop("annotation_sets")
+            document.save()
+
             doc_dict = document.get_doc_annotation_dict("raw", anonymize=True)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():
@@ -1329,6 +1333,10 @@ class TestDocumentAnnotationModelExport(TestCase):
     def test_export_raw_deanonymized(self):
 
         for document in self.project.documents.all():
+            # Mask any existing annotations that came with the document upload
+            document.data.pop("annotation_sets")
+            document.save()
+
             doc_dict = document.get_doc_annotation_dict("raw", anonymize=False)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():
@@ -1342,6 +1350,10 @@ class TestDocumentAnnotationModelExport(TestCase):
     def test_export_gate_anonymized(self):
 
         for document in self.project.documents.all():
+            # Mask any existing annotations that came with the document upload
+            document.data.pop("annotation_sets")
+            document.save()
+
             doc_dict = document.get_doc_annotation_dict("gate", anonymize=True)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():
@@ -1353,6 +1365,10 @@ class TestDocumentAnnotationModelExport(TestCase):
     def test_export_gate_deanonymized(self):
 
         for document in self.project.documents.all():
+            # Mask any existing annotations that came with the document upload
+            document.data.pop("annotation_sets")
+            document.save()
+
             doc_dict = document.get_doc_annotation_dict("gate", anonymize=False)
 
             for aset_key, aset_data in doc_dict["annotation_sets"].items():

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1102,7 +1102,7 @@ class TestDocumentAnnotationModelExport(TestCase):
         self.test_user = get_user_model().objects.create(username="project_creator")
         self.annotator_names = [f"{self.unanonymized_prefix}{i}" for i in range(3)]
         self.annotators = [get_user_model().objects.create(username=u) for u in self.annotator_names]
-        self.annotator_ids = [a.id for a in self.annotators]
+        self.anon_annotator_names = [f"{settings.ANONYMIZATION_PREFIX}{a.id}" for a in self.annotators]
         self.project = Project.objects.create(owner=self.test_user)
         for i in range(10):
             document = Document.objects.create(
@@ -1157,7 +1157,7 @@ class TestDocumentAnnotationModelExport(TestCase):
             self.assertTrue("feature3" in doc_dict)
 
             self.check_raw_gate_annotation_formatting(doc_dict)
-            self.check_teamware_status(doc_dict, self.annotator_ids)
+            self.check_teamware_status(doc_dict, self.anon_annotator_names)
 
     def test_export_gate(self):
 
@@ -1174,7 +1174,7 @@ class TestDocumentAnnotationModelExport(TestCase):
             self.assertTrue("feature3" in doc_features)
 
             self.check_raw_gate_annotation_formatting(doc_dict)
-            self.check_teamware_status(doc_features, self.annotator_ids)
+            self.check_teamware_status(doc_features, self.anon_annotator_names)
 
     def check_raw_gate_annotation_formatting(self, doc_dict):
         self.assertTrue("annotation_sets" in doc_dict)
@@ -1226,7 +1226,7 @@ class TestDocumentAnnotationModelExport(TestCase):
                 self.assertTrue(isinstance(anno_set_dict[set_key]["text1"], str))
                 self.assertTrue(isinstance(anno_set_dict[set_key]["checkbox1"], str))
 
-            self.check_teamware_status(doc_dict, ",".join(str(i) for i in self.annotator_ids))
+            self.check_teamware_status(doc_dict, ",".join(str(i) for i in self.anon_annotator_names))
 
     def test_export_raw_anonymized(self):
 
@@ -1237,7 +1237,7 @@ class TestDocumentAnnotationModelExport(TestCase):
                 self.assertFalse(aset_key.startswith(self.unanonymized_prefix))
                 self.assertFalse(aset_data.get("name", None).startswith(self.unanonymized_prefix))
 
-            self.check_teamware_status(doc_dict, self.annotator_ids)
+            self.check_teamware_status(doc_dict, self.anon_annotator_names)
 
     def test_export_raw_deanonymized(self):
 
@@ -1261,7 +1261,7 @@ class TestDocumentAnnotationModelExport(TestCase):
                 self.assertFalse(aset_key.startswith(self.unanonymized_prefix))
                 self.assertFalse(aset_data.get("name", None).startswith(self.unanonymized_prefix))
 
-            self.check_teamware_status(doc_dict["features"], self.annotator_ids)
+            self.check_teamware_status(doc_dict["features"], self.anon_annotator_names)
 
     def test_export_gate_deanonymized(self):
 

--- a/docs/docs/manageradminguide/documents_annotations_management.md
+++ b/docs/docs/manageradminguide/documents_annotations_management.md
@@ -234,7 +234,7 @@ You can choose how documents are exported:
 
     In anonymous mode the name `user1` would instead be the user's opaque numeric identifier (e.g. `105`).
 
-    The field `teamware_status` gives the ids or usernames (depending on the "anonymize" setting) of those annotators
+    The field `teamware_status` gives the usernames or anonymous IDs (depending on the "anonymize" setting) of those annotators
     who rejected the document, "timed out" because they did not complete their annotation in the time allowed by the
     project, or "aborted" for some other reason (e.g. they were removed from the project).
 

--- a/docs/docs/manageradminguide/documents_annotations_management.md
+++ b/docs/docs/manageradminguide/documents_annotations_management.md
@@ -187,12 +187,11 @@ possible to determine which documents were annotated by _the same person_, just 
 You can choose how documents are exported:
 
 * `.json` & `.jsonl` - JSON or JSON Lines files can be generated in the format of:
-  * `raw` - Exports unmodified JSON. If you've originally uploaded in GATE format then choose this option.
-
-    An additional field named `annotation_sets` is added for storing annotations. The annotations are laid out in the
-    same way as GATE JSON format. For example if a document has been annotated by `user1` with labels and values
-    `text`:`Annotation text`, `radio`:`val3`, and `checkbox`:`["val2", "val4"]`, the non-anonymous export might look
-    like this:
+  * `raw` - Exports the original `JSON` combined with an additional field named `annotation_sets` for storing
+    annotations. The annotations are laid out in the same way as GATE
+    [bdocjs](https://gatenlp.github.io/gateplugin-Format_Bdoc/bdoc_document.html) format. For example if a document
+    has been annotated by `user1` with labels and values `text`:`Annotation text`, `radio`:`val3`, and
+    `checkbox`:`["val2", "val4"]`, the non-anonymous export might look like this:
 
     ```json
     {
@@ -210,14 +209,12 @@ You can choose how documents are exported:
                  "end":10,
                  "id":0,
                  "features":{
-                    "label":{
-                       "text":"Annotation text",
-                       "radio":"val3",
-                       "checkbox":[
-                          "val2",
-                          "val4"
-                       ]
-                    }
+                     "text":"Annotation text",
+                     "radio":"val3",
+                     "checkbox":[
+                        "val2",
+                        "val4"
+                     ]
                  }
               }
            ],
@@ -232,16 +229,18 @@ You can choose how documents are exported:
     }
     ```
 
-    In anonymous mode the name `user1` would instead be the user's opaque numeric identifier (e.g. `105`).
+    In anonymous mode the name `user1` would instead be derived from the user's opaque numeric identifier (e.g.
+    `annotator105`).
 
     The field `teamware_status` gives the usernames or anonymous IDs (depending on the "anonymize" setting) of those annotators
     who rejected the document, "timed out" because they did not complete their annotation in the time allowed by the
     project, or "aborted" for some other reason (e.g. they were removed from the project).
 
-  * `gate` - Convert documents to GATE JSON format and export. A `name` field is added that takes the ID value from the
-    ID field specified in the project configuration. Fields apart from `text` and the ID field specified in the project
-    config are placed in the `features` field, as is the `teamware_status` information. An `annotation_sets` field is
-    added for storing annotations.
+  * `gate` - Convert documents to GATE [bdocjs](https://gatenlp.github.io/gateplugin-Format_Bdoc/bdoc_document.html)
+    format and export.  A `name` field is added that takes the `ID` value from the `ID field` specified in the
+    **project configuration**. Any top-level fields apart from `text`, `features`, `offset_type`, `annotation_sets`,
+    and the ID field specified in the project config are placed in the `features` field, as is the `teamware_status`
+    information. An `annotation_sets` field is added for storing annotations if it doesn't already exist.
 
     For example in the case of this uploaded JSON document:
     ```json
@@ -270,6 +269,9 @@ You can choose how documents are exported:
 * `.csv` - The JSON documents will be flattened to csv's column based format. Annotations are added as additional
   columns with the header of `annotations.username.label` and the status information is in columns named
   `teamware_status.rejected_by`, `teamware_status.timed_out` and `teamware_status.aborted`.
+
+**Note: Documents that contains existing annotations (i.e. the `annotation_sets` field for `JSON` or `annotations` for `CSV`) are merged with the new sets of annotations. Be aware that if the document has a new annotation from an annotator with the same
+username, the previous annotation will be overwritten. Existing annotations are also not anonymized when exporting the document.**
 
 ## Deleting documents and annotations
 

--- a/teamware/settings/base.py
+++ b/teamware/settings/base.py
@@ -266,6 +266,11 @@ DELETED_USER_LASTNAME = "Deleted"
 DELETED_USER_EMAIL_DOMAIN = "teamware-deleted.com"
 
 """
+Anonymization settings
+"""
+ANONYMIZATION_PREFIX = "annotator"
+
+"""
 Frontend dev server configuration
 """
 FRONTEND_DEV_SERVER_USE = True


### PR DESCRIPTION
- Resolves #345 
  - Username now anonymized for both `name` field and keys inside `annotation_sets`
  - Configurable string prefix added to anonymized name (`settings.ANONYMIZATION_PREFIX`), defaults to `annotator`
  - Fixed the tests to check the anonymization
- Resolves #346 
  - Append to the `features` field if exporting as GATE format
  - Updated `test_export_gate` to check for this
- Resolves #347 
  - `features` field for each annotation now directly has content of the annotation instead of being nested in a `label` field
  - Updated `check_raw_gate_annotation_formatting` to check for this
- Resolves #348
  - Existing annotations are merged with new annotation. For JSON exports it's the `annotation_sets` field while for CSV it's  `annotations` field
  - If keys conflict, new annotation overwrites the older one
  - Updated `check_raw_gate_annotation_formatting` and `test_export_csv` to check for this behaviour
- Updated docs to reflect these changes.

