### PR TITLE
Support upgrades as well as fresh installs for get-teamware.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ bash ./get-teamware.sh
 
 [A Helm chart](https://github.com/GateNLP/charts/tree/main/gate-teamware) is also available to allow deployment on Kubernetes.
 
+### Upgrading
+
+**When upgrading GATE Teamware it is strongly recommended to ensure you have a recent backup of your database before starting the upgrade procedure.**  Database schema changes should be applied automatically as part of the upgrade but unexpected errors may cause data corruption - **always** take a backup before starting any significant changes to your database, so you can roll back in the event of failure.
+
+Check the [changelog](CHANGELOG.md) - any breaking changes and special considerations for upgrades to particular versions will be documented there.
+
+To upgrade a GATE Teamware installation that you installed using `get-teamware.sh`, simply download and run the latest version of the script in the same folder.  It will detect your existing configuration and prompt you for any new settings that have been introduced in the new version.  Note that any manual changes you have made to the `docker-compose.yml` and other files will not be duplicated automatically for the new version, you will have to port the necessary changes to the new files by hand.
+
+Upgrading a Kubernetes deployment generally consists simply of installing the new chart version with `help upgrade`.  As above, check the GATE Teamware changelog and the [chart readme](https://github.com/GateNLP/charts/tree/main/gate-teamware) for any special considerations, new or changed configuration values, etc. and ensure you have a recent database backup before starting the upgrade process.
+
 ## Building locally
 Follow these steps to run the app on your local machine using `docker-compose`:
 1. Clone this repository by running `git clone https://github.com/GateNLP/gate-teamware.git` and move into the `gate-teamware` directory.

--- a/generate-docker-env.sh
+++ b/generate-docker-env.sh
@@ -20,7 +20,9 @@ if [ -f .env ]; then
   cp .env saved-env.$BAKNAME
 
   # load any existing environment variables from .env
-  . .env
+  if [ -z "$SKIP_EXISTING_ENV" ]; then
+    . .env
+  fi
    sed -n '/^### generate-docker-env\.sh will not touch anything below this line/,$p' .env | sed 1d > .env.tmpsave
 fi
 

--- a/install/get-teamware.sh
+++ b/install/get-teamware.sh
@@ -263,6 +263,8 @@ chmod 644 nginx/*.template Caddyfile
 
 echo "Generating configuration file"
 
+# tell generate-docker-env not to load an existing .env itself, since we already have
+SKIP_EXISTING_ENV=yes
 source ./generate-docker-env.sh
 
 if [ "${COMPOSE[0]/ /_}" = "${COMPOSE[0]}" ]; then

--- a/install/get-teamware.sh
+++ b/install/get-teamware.sh
@@ -52,14 +52,47 @@ fi
 
 # Gather information for env file
 set -a
-echo 'GATE Teamware needs to know the public host name at which it will be accessed'
-echo 'by users - only connections to that host name or "localhost" are accepted.'
-read -e -p 'Public hostname of GATE Teamware [default localhost]: ' DJANGO_ALLOWED_HOSTS
-if [ -z "$DJANGO_ALLOWED_HOSTS" ]; then
-  DJANGO_ALLOWED_HOSTS=localhost
+
+if [ -f .env -a -f docker-compose.yml ]; then
+  echo 'Existing settings found, assuming this is an upgrade.'
+  NEW__IMAGE_TAG="${IMAGE_TAG}"
+  . .env
+  OLD__IMAGE_TAG="${IMAGE_TAG}"
+  IMAGE_TAG="${NEW__IMAGE_TAG}"
+  if [ "${OLD__IMAGE_TAG}" = "${NEW__IMAGE_TAG}" ]; then
+    echo "This is the installation script for ${NEW__IMAGE_TAG}, but you already have this version."
+    read -e -p 'Do you wish to continue? [y/N]: ' CONTINUE_UPGRADE
+    case "$CONTINUE_UPGRADE" in
+      [Yy]*)
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+  else
+    echo "Upgrading from ${OLD__IMAGE_TAG} to ${IMAGE_TAG}"
+  fi
 fi
 
-read -e -p 'Will users connect to GATE Teamware via https? [Y/n]: ' IS_HTTPS
+OLD__DJANGO_ALLOWED_HOSTS=${DJANGO_ALLOWED_HOSTS:-localhost}
+echo 'GATE Teamware needs to know the public host name at which it will be accessed'
+echo 'by users - only connections to that host name or "localhost" are accepted.'
+read -e -p "Public hostname of GATE Teamware [default $OLD__DJANGO_ALLOWED_HOSTS]: " DJANGO_ALLOWED_HOSTS
+if [ -z "$DJANGO_ALLOWED_HOSTS" ]; then
+  DJANGO_ALLOWED_HOSTS=${OLD__DJANGO_ALLOWED_HOSTS}
+fi
+
+DEFAULT__IS_HTTPS=Y
+case "$DJANGO_APP_URL" in
+  http:*)
+    DEFAULT__IS_HTTPS=N
+    ;;
+esac
+
+read -e -p "Will users connect to GATE Teamware via https? (default ${DEFAULT__IS_HTTPS}): " IS_HTTPS
+if [ -z "$IS_HTTPS" ]; then
+  IS_HTTPS=$DEFAULT__IS_HTTPS
+fi
 
 case $IS_HTTPS in
   [Nn]*)
@@ -70,33 +103,70 @@ case $IS_HTTPS in
     ;;
 esac
 
-read -e -p 'Email address of initial "admin" user [default "teamware@example.com"]: ' SUPERUSER_EMAIL
-read -e -p 'Initial password for "admin" user [default "password"]: ' SUPERUSER_PASSWORD
+if [ -z "$SUPERUSER_EMAIL" ]; then
+  read -e -p 'Email address of initial "admin" user [default "teamware@example.com"]: ' SUPERUSER_EMAIL
+  read -e -p 'Initial password for "admin" user [default "password"]: ' SUPERUSER_PASSWORD
+fi
 
 echo ''
-echo 'GATE Teamware needs to be able to send outgoing email for password resets, etc.'
-echo 'You can configure an SMTP server here, or edit your settings later to use the'
-echo 'GMail API.'
-read -e -p 'SMTP server hostname: ' DJANGO_EMAIL_HOST
-read -e -p 'SMTP server port number [default 587, may be 25 or 465]: ' DJANGO_EMAIL_PORT
-read -e -p 'SMTP server username, if required: ' DJANGO_EMAIL_HOST_USER
-read -e -s -p 'SMTP server password, if required: ' DJANGO_EMAIL_HOST_PASSWORD
-echo "" # read -s doesn't add a line break
-read -e -p 'Does SMTP server require a secure connection? [Y/n]: ' EMAIL_SECURE
-
-case "$EMAIL_SECURE" in
-  [Nn]*)
-    DJANGO_EMAIL_SECURITY=
-    ;;
-
-  *)
-    if [ "$DJANGO_EMAIL_PORT" = "465" ]; then
-      DJANGO_EMAIL_SECURITY=ssl
-    else
-      DJANGO_EMAIL_SECURITY=tls
+if [ "$DJANGO_EMAIL_BACKEND" = "gmailapi_backend.mail.GmailBackend" ]; then
+  echo "GATE Teamware is currently configured to send email using the Gmail API,"
+  echo "these settings cannot be modified here, you should edit the .env file"
+  echo "yourself later."
+else
+  if [ -n "$DJANGO_EMAIL_HOST" ]; then
+    echo "Current outgoing email server settings:"
+    echo "Hostname: ${DJANGO_EMAIL_HOST}"
+    echo "Port: ${DJANGO_EMAIL_PORT}"
+    if [ -n "${DJANGO_EMAIL_HOST_USER}" ]; then
+      echo "Username: ${DJANGO_EMAIL_HOST_USER}"
     fi
-    ;;
-esac
+    if [ -n "${DJANGO_EMAIL_HOST_PASSWORD}" ]; then
+      echo "Password: <hidden>"
+    fi
+    case "${DJANGO_EMAIL_SECURITY}" in
+      ssl|tls)
+        echo "Secure connection: Y"
+        ;;
+      *)
+        echo "Secure connection: N"
+        ;;
+    esac
+    echo ""
+    read -p "Change these settings? (y/N): " EDIT_EMAIL_SETTINGS
+    case "$EDIT_EMAIL_SETTINGS" in
+      [yY]*)
+        unset DJANGO_EMAIL_HOST
+      ;;
+    esac
+  fi
+
+  if [ -z "$DJANGO_EMAIL_HOST" ]; then
+    echo 'GATE Teamware needs to be able to send outgoing email for password resets, etc.'
+    echo 'You can configure an SMTP server here, or edit your settings later to use the'
+    echo 'GMail API.'
+    read -e -p 'SMTP server hostname: ' DJANGO_EMAIL_HOST
+    read -e -p 'SMTP server port number [default 587, may be 25 or 465]: ' DJANGO_EMAIL_PORT
+    read -e -p 'SMTP server username, if required: ' DJANGO_EMAIL_HOST_USER
+    read -e -s -p 'SMTP server password, if required: ' DJANGO_EMAIL_HOST_PASSWORD
+    echo "" # read -s doesn't add a line break
+    read -e -p 'Does SMTP server require a secure connection? [Y/n]: ' EMAIL_SECURE
+
+    case "$EMAIL_SECURE" in
+      [Nn]*)
+        DJANGO_EMAIL_SECURITY=
+        ;;
+
+      *)
+        if [ "$DJANGO_EMAIL_PORT" = "465" ]; then
+          DJANGO_EMAIL_SECURITY=ssl
+        else
+          DJANGO_EMAIL_SECURITY=tls
+        fi
+        ;;
+    esac
+  fi
+fi
 
 echo 'Privacy policy / Terms & conditions'
 echo ''
@@ -108,16 +178,33 @@ echo 'If the default policies are not suitable for your needs you will need to'
 echo 'create your own and save them in the "custom-policies" folder as Markdown.'
 echo 'See the template files in that folder for more details.'
 echo ''
-read -e -p 'Legal name of the entity responsible for this Teamware: ' PP_HOST_NAME
-read -e -p 'Physical address of this entity: ' PP_HOST_ADDRESS
-read -e -p 'Contact email address or web URL (including http(s)://) for the host: ' PP_HOST_EMAIL_OR_URL
 
-if [ "${PP_HOST_EMAIL_OR_URL#http://}" != "$PP_HOST_EMAIL_OR_URL" ] || [ "${PP_HOST_EMAIL_OR_URL#https://}" != "$PP_HOST_EMAIL_OR_URL" ]; then
-  # it's a URL
-  PP_HOST_CONTACT="<a href='${PP_HOST_EMAIL_OR_URL}'>Contact $PP_HOST_NAME</a>"
-else
-  # assume it's an email
-  PP_HOST_CONTACT="<a href='mailto:${PP_HOST_EMAIL_OR_URL}'>Email $PP_HOST_NAME</a>"
+if [ -n "$PP_HOST_NAME" ]; then
+  echo 'Current settings for privacy policy and terms:'
+  echo "Legal name of the entity responsible for this Teamware: $PP_HOST_NAME"
+  echo "Physical address of this entity: $PP_HOST_ADDRESS"
+  echo "Contact link: $PP_HOST_CONTACT"
+  echo ""
+  read -p "Change these settings? (y/N): " EDIT_PP_SETTINGS
+  case "$EDIT_PP_SETTINGS" in
+    [yY]*)
+      unset PP_HOST_NAME
+    ;;
+  esac
+fi
+
+if [ -z "$PP_HOST_NAME" ]; then
+  read -e -p 'Legal name of the entity responsible for this Teamware: ' PP_HOST_NAME
+  read -e -p 'Physical address of this entity: ' PP_HOST_ADDRESS
+  read -e -p 'Contact email address or web URL (including http(s)://) for the host: ' PP_HOST_EMAIL_OR_URL
+
+  if [ "${PP_HOST_EMAIL_OR_URL#http://}" != "$PP_HOST_EMAIL_OR_URL" ] || [ "${PP_HOST_EMAIL_OR_URL#https://}" != "$PP_HOST_EMAIL_OR_URL" ]; then
+    # it's a URL
+    PP_HOST_CONTACT="<a href='${PP_HOST_EMAIL_OR_URL}'>Contact $PP_HOST_NAME</a>"
+  else
+    # assume it's an email
+    PP_HOST_CONTACT="<a href='mailto:${PP_HOST_EMAIL_OR_URL}'>Email $PP_HOST_NAME</a>"
+  fi
 fi
 
 echo ''
@@ -125,9 +212,18 @@ echo 'GATE Teamware normally requires new users to confirm their email address'
 echo 'by clicking a link in an activation email.  If you are just testing GATE'
 echo 'Teamware locally you may wish to disable this so new accounts are active'
 echo 'immediately.'
-read -e -p 'Require new users to confirm their email address? [Y/n]: ' EMAIL_ACTIVATION
+case "${DJANGO_ACTIVATION_WITH_EMAIL:-yes}" in
+  [Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn])
+    DEFAULT__EMAIL_ACTIVATION=y
+    ;;
 
-case "$EMAIL_ACTIVATION" in
+  *)
+    DEFAULT__EMAIL_ACTIVATION=n
+    ;;
+esac
+read -e -p "Require new users to confirm their email address? [y/n, default $DEFAULT__EMAIL_ACTIVATION]: " EMAIL_ACTIVATION
+
+case "${EMAIL_ACTIVATION:-$DEFAULT__EMAIL_ACTIVATION}" in
   [Nn]*)
     DJANGO_ACTIVATION_WITH_EMAIL=no
     ;;
@@ -141,13 +237,25 @@ set +a
 
 # Download install package
 if [ "$IMAGE_TAG" = "latest" -o "$IMAGE_TAG" = "dev" ]; then
-  "${CURL[@]}" https://github.com/GateNLP/gate-teamware/releases/latest/download/install.tar.gz | tar xzf -
+  "${CURL[@]}" https://github.com/GateNLP/gate-teamware/releases/latest/download/install.tar.gz > install.tar.gz
 else
-  "${CURL[@]}" https://github.com/GateNLP/gate-teamware/releases/download/v${IMAGE_TAG}/install.tar.gz | tar xzf -
+  "${CURL[@]}" https://github.com/GateNLP/gate-teamware/releases/download/v${IMAGE_TAG}/install.tar.gz > install.tar.gz
 fi
 
+# Back up any files that would be overwritten when unpacking the tar.gz - there
+# is an option that will do this automatically in GNU tar but it doesn't work
+# with the BSD tar in Mac OS X
+tar tzf install.tar.gz | while read FILENAME ; do
+  if [ -f "$FILENAME" ]; then
+    cp "$FILENAME" "$FILENAME.bak"
+  fi
+done
+
+# Now unpack the archive
+tar xzf install.tar.gz
+
 # Create backup folder
-mkdir backups
+mkdir -p backups
 
 # Double check permissions on the files that will be bind-mounted
 chmod 755 nginx create-django-db.sh custom-policies
@@ -204,4 +312,14 @@ to include a simple HTTPS reverse proxy server that obtains certificates from
 LetsEncrypt.  If this host is not internet-accessible you will need to set up
 your own reverse proxy server elsewhere.
 EOF
+fi
+
+if [ -n "$NEW__IMAGE_TAG" ]; then
+  echo ""
+  echo "Existing files that were part of your previous version of GATE Teamware"
+  echo "have been backed up with a .bak extension. If you have made any modifications"
+  echo "to any of these files since you originally installed GATE Teamware (for"
+  echo "example to change the public port number in docker-compose.yml) then you"
+  echo "will need to compare the backup files to their new versions and make the"
+  echo "appropriate changes yourself."
 fi

--- a/install/get-teamware.sh
+++ b/install/get-teamware.sh
@@ -54,6 +54,27 @@ fi
 set -a
 
 if [ -f .env -a -f docker-compose.yml ]; then
+
+  if [ ! ( -f create-django-db.sh -a -f generate-docker-env.sh ) ]; then
+    echo 'You have run this upgrade script in a folder that contains a docker compose'
+    echo 'application stack, but it does not appear to be an installation of GATE'
+    echo 'Teamware.  You should run this script either in a completely empty directory'
+    echo 'if you want to install a fresh copy of GATE Teamware, or in the directory'
+    echo 'containing an existing installation that you want to upgrade.  Running in'
+    echo 'a directory that contains a different docker compose application stack will'
+    echo 'not work and may cause damage or data loss.'
+    echo ''
+    read -e -p 'Do you wish to continue anyway? [y/N]: ' CONTINUE_UPGRADE
+    case "$CONTINUE_UPGRADE" in
+      [Yy]*)
+        unset CONTINUE_UPGRADE
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+  fi
+
   echo 'Existing settings found, assuming this is an upgrade.'
   NEW__IMAGE_TAG="${IMAGE_TAG}"
   . .env


### PR DESCRIPTION
This is an attempt to address #380 by adding logic to the `get-teamware.sh` script to detect if it is being run in a folder that already has an existing Teamware installation, and if so then behave as an _upgrade_ rather than as a fresh installation.  A couple of questions for @johann-petrak:

- currently we detect whether it is an upgrade or a fresh install by looking for files named `docker-compose.yml` and `.env` in the current directory - should we be more specific and look for some more Teamware-specific files like `generate-docker-env.sh` so we don't get confused if the script is run in a folder with some _other_ compose stack that isn't teamware?
- I've documented this in the `README.md` but does it need more documentation anywhere else?