### PR TITLE
Attempt to spread documents more evenly across annotators

### DIFF
--- a/backend/tests/test_rpc_endpoints.py
+++ b/backend/tests/test_rpc_endpoints.py
@@ -1609,10 +1609,11 @@ class TestAnnotationTaskManagerTrainTestMode(TestEndpoint):
         self.proj.save()
 
         docs_annotated_per_user = []
-        for (i, (ann_user, _)) in enumerate(self.annotators):
+        for (ann_user, _) in self.annotators:
             # Add to project
             self.assertTrue(add_project_annotator(self.manager_request, self.proj.id, ann_user.username))
 
+        for (i, (ann_user, _)) in enumerate(self.annotators):
             # Every annotator should be able to complete every training document, even though
             # max annotations per document is less than the total number of annotators
             self.assertEqual(self.num_training_docs,
@@ -1623,6 +1624,7 @@ class TestAnnotationTaskManagerTrainTestMode(TestEndpoint):
             self.assertEqual(self.num_training_docs,
                              self.proj.get_annotator_document_score(ann_user, DocumentType.TRAINING))
 
+        for (i, (ann_user, _)) in enumerate(self.annotators):
             # Every annotator should be able to complete every test document, even though
             # max annotations per document is less than the total number of annotators
             self.assertEqual(self.num_test_docs,
@@ -1633,6 +1635,7 @@ class TestAnnotationTaskManagerTrainTestMode(TestEndpoint):
             self.assertEqual(self.num_training_docs,
                              self.proj.get_annotator_document_score(ann_user, DocumentType.TRAINING))
 
+        for (i, (ann_user, _)) in enumerate(self.annotators):
             # Now attempt to complete task normally
             num_annotated = self.complete_annotations(self.num_docs, "Annotation", annotator=i)
             docs_annotated_per_user.append(num_annotated)

--- a/backend/tests/test_rpc_endpoints.py
+++ b/backend/tests/test_rpc_endpoints.py
@@ -1379,7 +1379,7 @@ class TestAnnotationTaskManagerTrainTestMode(TestEndpoint):
         self.num_training_docs = 5
         self.training_docs = []
         for i in range(self.num_training_docs):
-            self.docs.append(Document.objects.create(project=self.proj,
+            self.training_docs.append(Document.objects.create(project=self.proj,
                                                      doc_type=DocumentType.TRAINING,
                                                      data={
                                                         "text": f"Document {i}",
@@ -1396,7 +1396,7 @@ class TestAnnotationTaskManagerTrainTestMode(TestEndpoint):
         self.num_test_docs = 10
         self.test_docs = []
         for i in range(self.num_test_docs):
-            self.docs.append(Document.objects.create(project=self.proj,
+            self.test_docs.append(Document.objects.create(project=self.proj,
                                                      doc_type=DocumentType.TEST,
                                                      data={
                                                          "text": f"Document {i}",


### PR DESCRIPTION
Rather than picking the next document for each annotator completely at random, we now prefer documents that have fewer existing annotations. This is achieved by first sorting the list of documents by the number of `COMPLETED+PENDING` annotations and then randomizing only within each group, i.e. we first try (in random order) those documents with no existing annotations, then if none of those are suitable we try (again in random order) those documents with one annotation, then two, etc. until we either find a valid document to assign or run out of documents to try.

The effect of this should be that at any given time the full set of documents should be "evenly" annotated, or as close as possible if the number of completed annotation does not divide evenly into `num_docs * annotations_per_doc`

Fixes #372