### PR TITLE
Update citation information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -76,6 +76,4 @@ preferred-citation:
   end: 151
   publisher:
     name: Association for Computational Linguistics
-  conference:
-    name: 17th Conference of the European Chapter of the Association for Computational Linguistics
-    year: 2023
+    address: Dubrovnik, Croatia

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -69,9 +69,13 @@ preferred-citation:
   doi: 10.18653/v1/2023.eacl-demo.17
   title: "GATE Teamware 2: An open-source tool for collaborative document classification annotation"
   collection-title: "Proceedings of the 17th Conference of the European Chapter of the Association for Computational Linguistics: System Demonstrations"    
+  location: Dubrovnik, Croatia
   year: 2023
   month: 5
   start: 145
   end: 151
   publisher:
     name: Association for Computational Linguistics
+  conference:
+    name: 17th Conference of the European Chapter of the Association for Computational Linguistics
+    year: 2023

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -69,11 +69,11 @@ preferred-citation:
   doi: 10.18653/v1/2023.eacl-demo.17
   title: "GATE Teamware 2: An open-source tool for collaborative document classification annotation"
   collection-title: "Proceedings of the 17th Conference of the European Chapter of the Association for Computational Linguistics: System Demonstrations"    
-  location: Dubrovnik, Croatia
+  location:
+    name: Dubrovnik, Croatia
   year: 2023
   month: 5
   start: 145
   end: 151
   publisher:
     name: Association for Computational Linguistics
-    address: Dubrovnik, Croatia

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -76,4 +76,4 @@ preferred-citation:
   publisher:
     name: Association for Computational Linguistics
   conference:
-    location: Dubrovnik, Croatia
+    address: Dubrovnik, Croatia

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -75,5 +75,3 @@ preferred-citation:
   end: 151
   publisher:
     name: Association for Computational Linguistics
-  conference:
-    address: Dubrovnik, Croatia

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 abstract: A web application for collaborative document annotation. GATE teamware provides
   a flexible web app platform for managing classification of documents by human annotators.
-authors:
+authors: 
 - affiliation: The University of Sheffield
   email: t.karmakharm@sheffield.ac.uk
   family-names: Karmakharm
@@ -38,3 +38,42 @@ title: GATE Teamware
 type: software
 url: https://gatenlp.github.io/gate-teamware/
 version: 2.1.1
+preferred-citation:
+  type: conference-paper
+  authors:
+  - affiliation: The University of Sheffield
+    email: d.wilby@sheffield.ac.uk
+    family-names: Wilby
+    given-names: David
+    orcid: https://orcid.org/0000-0002-6553-8739
+  - affiliation: The University of Sheffield
+    email: t.karmakharm@sheffield.ac.uk
+    family-names: Karmakharm
+    given-names: Twin
+    orcid: https://orcid.org/0000-0002-1888-7098
+  - affiliation: The University of Sheffield
+    email: i.roberts@sheffield.ac.uk
+    family-names: Roberts
+    given-names: Ian
+    orcid: https://orcid.org/0000-0002-7296-5851
+  - affiliation: The University of Sheffield
+    email: x.song@sheffield.ac.uk
+    family-names: Song
+    given-names: Xingyi
+    orcid: https://orcid.org/0000-0002-4188-6974
+  - affiliation: The University of Sheffield
+    email: k.bontcheva@sheffield.ac.uk
+    family-names: Bontcheva
+    given-names: Kalina
+    orcid: https://orcid.org/0000-0001-6152-9600
+  doi: 10.18653/v1/2023.eacl-demo.17
+  title: "GATE Teamware 2: An open-source tool for collaborative document classification annotation"
+  collection-title: "Proceedings of the 17th Conference of the European Chapter of the Association for Computational Linguistics: System Demonstrations"    
+  year: 2023
+  month: 5
+  start: 145
+  end: 151
+  publisher:
+    name: Association for Computational Linguistics
+  conference:
+    location: Dubrovnik, Croatia

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ We welcome contributions to this open source project. Please [create a fork](htt
 Teamware is developed by the [GATE](https://gate.ac.uk) team, an academic research group at The University of Sheffield. As a result, future funding relies on evidence of the impact that the software provides. If you use Teamware, please let us know using the contact form at [gate.ac.uk](https://gate.ac.uk/g8/contact). Please include details on grants, publications, commercial products etc. Any information that can help us to secure future funding for our work is greatly appreciated.
 
 ## Citation
-For published work that has used Teamware, please cite this repository. One way is to include a citation such as:
+For published work that has used Teamware, please cite the [EACL23 demo paper](https://aclanthology.org/2023.eacl-demo.17/). One way is to include a citation such as:
 
-> Karmakharm, T., Wilby, D., Roberts, I., & Bontcheva, K. (2022). GATE Teamware (Version 2.1.1) [Computer software]. https://github.com/GateNLP/gate-teamware
+> Wilby, D., Karmakharm, T., Roberts, I., Song, X. & Bontcheva, K. (2023). GATE Teamware 2: An open-source tool for collaborative document classification annotation. In Proceedings of the 17th Conference of the European Chapter of the Association for Computational Linguistics: System Demonstrations, pages 145–151, Dubrovnik, Croatia. Association for Computational Linguistics. https://aclanthology.org/2023.eacl-demo.17/
 
 Please use the `Cite this repository` button at the top of the [project's GitHub repository](https://github.com/GATENLP/gate-teamware) to get an up to date citation.
 
+Permanent references to each version of the software are available from [Zenodo](https://doi.org/10.5281/zenodo.7899193).
 
 [docs]: https://gatenlp.github.io/gate-teamware/
 [dev-docs]: https://gatenlp.github.io/gate-teamware/development/developerguide/

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -129,10 +129,10 @@ Please make bug reports and feature requests as Issues on the [GATE Teamware Git
 Teamware is developed by the [GATE](https://gate.ac.uk) team, an academic research group at The University of Sheffield. As a result, future funding relies on evidence of the impact that the software provides. If you use Teamware, please let us know using the contact form at [gate.ac.uk](https://gate.ac.uk/g8/contact). Please include details on grants, publications, commercial products etc. Any information that can help us to secure future funding for our work is greatly appreciated.
 
 ## Citation
-For published work that has used Teamware, please cite this repository. One way is to include a citation such as:
+For published work that has used Teamware, please cite the [EACL23 demo paper](https://aclanthology.org/2023.eacl-demo.17/). One way is to include a citation such as:
 
-> Karmakharm, T., Wilby, D., Roberts, I., & Bontcheva, K. (2022). GATE Teamware (Version 0.1.4) [Computer software]. https://github.com/GateNLP/gate-teamware
+> Wilby, D., Karmakharm, T., Roberts, I., Song, X. & Bontcheva, K. (2023). GATE Teamware 2: An open-source tool for collaborative document classification annotation. In Proceedings of the 17th Conference of the European Chapter of the Association for Computational Linguistics: System Demonstrations, pages 145–151, Dubrovnik, Croatia. Association for Computational Linguistics. https://aclanthology.org/2023.eacl-demo.17/
 
 Please use the `Cite this repository` button at the top of the [project's GitHub repository](https://github.com/GATENLP/gate-teamware) to get an up to date citation.
 
-The Teamware version can be found on the 'About' page of your Teamware instance.
+Permanent references to each version of the software are available from [Zenodo](https://doi.org/10.5281/zenodo.7899193). The Teamware version can be found on the 'About' page of your Teamware instance.

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -12,16 +12,21 @@
 
     <h3>Citation</h3>
     <p>
-    For published work that has used Teamware, please cite the <a href="https://github.com/GATENLP/gate-teamware" target="_blank">project's GitHub repository</a>. One way is to include a citation such as:
+    For published work that has used Teamware, please cite the <a href="https://aclanthology.org/2023.eacl-demo.17/" target="_blank">EACL23 demo paper</a>. One way is to include a citation such as:
     </p>
 
     <p>
     <blockquote>
-      Karmakharm, T., Wilby, D., Roberts, I., & Bontcheva, K. (2022). GATE Teamware (Version {{ appVersion }}) [Computer software]. https://github.com/GateNLP/gate-teamware
+      Wilby, D., Karmakharm, T., Roberts, I., Song, X. & Bontcheva, K. (2023). GATE Teamware 2: An open-source tool for collaborative document classification annotation. In Proceedings of the 17th Conference of the European Chapter of the Association for Computational Linguistics: System Demonstrations, pages 145–151, Dubrovnik, Croatia. Association for Computational Linguistics. https://aclanthology.org/2023.eacl-demo.17/
     </blockquote>
       </p>
 
-    Please use the <b>Cite this repository</b> button at the top of the <a href="https://github.com/GATENLP/gate-teamware" target="_blank">project's GitHub repository</a> to get an up to date citation.
+    <p>
+      Please use the <b>Cite this repository</b> button at the top of the <a href="https://github.com/GATENLP/gate-teamware" target="_blank">project's GitHub repository</a> to get an up to date citation.
+    </p>
+    <p>
+      Permanent references to each version of the software are available from <a href="https://doi.org/10.5281/zenodo.7899193">Zenodo</a>.
+    </p>
 
     <h3>Version</h3>
     <p>

--- a/version.py
+++ b/version.py
@@ -8,8 +8,6 @@ PACKAGE_JSON_FILE_PATH = "package.json"
 DOCS_PACKAGE_JSON_FILE_PATH = "docs/package.json"
 CITATION_FILE_PATH = "CITATION.cff"
 MASTER_VERSION_FILE = "VERSION"
-README_FILE_PATH = "README.md"
-README_VERSION_REGEX = r"\(Version ([^)]*)\)"
 
 def check():
     """
@@ -30,13 +28,10 @@ def check():
     citation_version = citation_file['version']
     print(f"{CITATION_FILE_PATH} version is {citation_version}")
 
-    readme_version = get_readme_version(README_FILE_PATH)
-    print(f"{README_FILE_PATH} version is {readme_version}")
-
     master_version = get_master_version()
     print(f"VERSION file version is {master_version}")
 
-    if js_version != master_version or docs_js_version != master_version or citation_version != master_version or readme_version != master_version:
+    if js_version != master_version or docs_js_version != master_version or citation_version != master_version:
         print("One or more versions does not match")
         sys.exit(1)
     else:
@@ -48,21 +43,6 @@ def get_package_json_version(file_path: str) -> str:
 
     js_version = package_json['version']
     return js_version
-
-def get_readme_version(file_path: str) -> str:
-    with open(file_path, 'r') as f:
-        readme_text = f.read()
-    
-    match = re.search(README_VERSION_REGEX, readme_text)
-
-    if match is None:
-        print(f"No version found in {README_FILE_PATH}.")
-        return
-    elif len(match.groups()) > 1:
-        print(f"{len(match.groups())} matches found in {README_FILE_PATH}, expected 1.")
-        return
-    else:
-        return match.groups(1)[0]
 
 def get_master_version():
     with open(MASTER_VERSION_FILE, "r") as f:
@@ -83,8 +63,6 @@ def update(master_version:str = None):
 
     update_package_json_version(DOCS_PACKAGE_JSON_FILE_PATH, master_version)
 
-    update_readme_version(README_FILE_PATH, master_version)
-
     with open(CITATION_FILE_PATH, "r") as f:
         citation_file = yaml.safe_load(f)
     print(f"Writing master version {master_version} to {CITATION_FILE_PATH}")
@@ -101,19 +79,6 @@ def update_package_json_version(file_path:str, version_no:str):
     with open(file_path, "w") as f:
         package_json['version'] = version_no
         json.dump(package_json, f, indent=2)
-
-def update_readme_version(file_path:str, version_no:str):
-    with open(file_path, 'r') as f:
-        readme_text = f.read()
-    
-    readme_text = re.sub(
-           README_VERSION_REGEX, 
-           f'(Version {version_no})', 
-           readme_text
-       )
-
-    with open(file_path, 'w') as f:
-        f.write(readme_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Created this PR at Ian's request.

* Updated the suggested citation in all the places I could find it (repo README, latest docs README, about page) to suggest citing the demo paper. I've also added a more prominent link to Zenodo.
* In CITATION.cff I've added the paper as the `preferred-citation`. GitHub will show this citation instead, and it semantically indicates it's a related but different work (preserving all the top-level information about the software itself). As far as I can tell this is the only way to alter the GitHub Cite this Repository tool - it's not possible to show both a code and paper option.
* Remove the README version check/update from version.py, since the GitHub URL citation including has been removed

I tried to get GitHub's generated bibtex to match ACL Anthology's, but I can't get it to show the `address` field with the conference's location. I believe this is the only field that's commonly displayed that's different.
