### PR TITLE
Add explicit setting for "no email security"

### DIFF
--- a/install/get-teamware.sh
+++ b/install/get-teamware.sh
@@ -175,7 +175,7 @@ else
 
     case "$EMAIL_SECURE" in
       [Nn]*)
-        DJANGO_EMAIL_SECURITY=
+        DJANGO_EMAIL_SECURITY=none
         ;;
 
       *)

--- a/teamware/settings/base.py
+++ b/teamware/settings/base.py
@@ -214,8 +214,10 @@ if 'DJANGO_EMAIL_SECURITY' in os.environ:
         EMAIL_USE_SSL = True
     elif os.environ['DJANGO_EMAIL_SECURITY'].lower() == 'tls':
         EMAIL_USE_TLS = True
+    elif os.environ['DJANGO_EMAIL_SECURITY'].lower() in ['', 'none']:
+        pass
     else:
-        raise ValueError("DJANGO_EMAIL_SECURITY, if set, must be either SSL or TLS")
+        raise ValueError("DJANGO_EMAIL_SECURITY, if set, must be either SSL or TLS, or 'none' for no security")
 
     if 'DJANGO_EMAIL_CLIENT_CERTIFICATE' in os.environ:
         # If certificate is set then key must also, and we want to raise an


### PR DESCRIPTION
The present mechanism for configuring that your email server uses _no_ security is to omit the `DJANGO_EMAIL_SECURITY` setting from `.env` altogether.  This is somewhat brittle as upgrades and some initial installation scenarios can either leave the variable wrongly set or modify it (from no security to TLS, as that is the default setting for new installs).

This PR allows an explicit

```
DJANGO_EMAIL_SECURITY=none
```

to represent an active choice of "no security" in a way that's less likely to be accidentally overwritten.

Closes #401